### PR TITLE
UI redesign: two-pane layout with collapsible sidebar

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,38 @@ Once your app is deployed and you have your production URL:
 
 3. Redeploy from the Vercel dashboard
 
+## Sample Data
+
+To load sample data for local development:
+
+```bash
+npm run import -- scripts/sample-data.csv local-dev-user
+```
+
+This imports 28 opportunities with a mix of statuses, dates, and companies. You can re-run it after resetting the database if you want a fresh start:
+
+```bash
+rm local.db
+npm run db:push
+npm run import -- scripts/sample-data.csv local-dev-user
+```
+
+To import your own data, create a CSV with these columns:
+
+```
+Application Date,Company,Role,Work Mode,Location,Status,Job URL
+```
+
+- **Application Date**: `MM/DD/YYYY` format
+- **Status**: `saved`, `applied`, `interviewing`, `offered`, `rejected`, `withdrawn`, or `accepted`
+- **Work Mode**: `remote`, `hybrid`, or `onsite`
+
+Then run:
+
+```bash
+npm run import -- path/to/your-data.csv local-dev-user
+```
+
 ## Scripts
 
 | Command | Description |
@@ -137,6 +169,7 @@ Once your app is deployed and you have your production URL:
 | `npm run db:push` | Push schema changes to the database |
 | `npm run db:generate` | Generate migration files |
 | `npm run db:studio` | Open Drizzle Studio to browse your data |
+| `npm run import -- <csv> <user-id>` | Import opportunities from a CSV file |
 
 ## Tech Stack
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,9 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  devIndicators: {
+    position: "bottom-right",
+  },
 };
 
 export default nextConfig;

--- a/scripts/import-csv.ts
+++ b/scripts/import-csv.ts
@@ -8,6 +8,7 @@ import { opportunities, users, statusHistory } from "../src/lib/db/schema";
 const STATUS_MAP: Record<string, string> = {
   applied: "applied",
   "initial screen": "interviewing",
+  interviewing: "interviewing",
   declined: "rejected",
   rejected: "rejected",
   offered: "offered",

--- a/scripts/sample-data.csv
+++ b/scripts/sample-data.csv
@@ -1,0 +1,29 @@
+Application Date,Company,Role,Work Mode,Location,Status,Job URL
+1/15/2026,Stripe,Senior Software Engineer,Remote,San Francisco CA,Applied,https://stripe.com/jobs/1234
+1/18/2026,Datadog,Staff Frontend Engineer,Hybrid,New York NY,Interviewing,https://careers.datadoghq.com/5678
+1/22/2026,Vercel,Full Stack Developer,Remote,,Applied,https://vercel.com/careers/9012
+1/25/2026,Cloudflare,Systems Engineer,Remote,Austin TX,Rejected,https://cloudflare.com/careers/3456
+2/01/2026,Figma,Senior Product Designer,Hybrid,San Francisco CA,Offered,https://figma.com/careers/7890
+2/03/2026,Linear,Software Engineer,Remote,,Interviewing,https://linear.app/careers/2345
+2/07/2026,Notion,Backend Engineer,Hybrid,New York NY,Applied,https://notion.so/careers/6789
+2/10/2026,Supabase,Developer Advocate,Remote,,Withdrawn,https://supabase.com/careers/0123
+2/14/2026,Planetscale,Database Engineer,Remote,,Rejected,https://planetscale.com/careers/4567
+2/18/2026,Retool,Frontend Engineer,Onsite,San Francisco CA,Interviewing,https://retool.com/careers/8901
+2/20/2026,Fly.io,Infrastructure Engineer,Remote,,Applied,https://fly.io/jobs/2345
+2/24/2026,Railway,Platform Engineer,Remote,,Saved,https://railway.app/careers/6789
+2/28/2026,Render,Site Reliability Engineer,Remote,,Applied,https://render.com/careers/0123
+3/02/2026,Tailwind Labs,UI Engineer,Remote,,Interviewing,https://tailwindcss.com/careers/4567
+3/05/2026,Prisma,Software Engineer,Remote,Berlin Germany,Rejected,https://prisma.io/careers/8901
+3/08/2026,Neon,Database Engineer,Remote,,Applied,https://neon.tech/careers/2345
+3/10/2026,Deno,Runtime Engineer,Remote,,Saved,https://deno.com/careers/6789
+3/12/2026,Turso,Backend Engineer,Remote,,Applied,https://turso.tech/careers/0123
+3/15/2026,Resend,Full Stack Engineer,Remote,,Interviewing,https://resend.com/careers/4567
+3/18/2026,Clerk,Senior Frontend Engineer,Remote,,Offered,https://clerk.com/careers/8901
+3/20/2026,Convex,Systems Engineer,Remote,,Applied,https://convex.dev/careers/2345
+3/22/2026,Upstash,Software Engineer,Remote,,Saved,https://upstash.com/careers/6789
+3/25/2026,Axiom,Observability Engineer,Remote,New York NY,Interviewing,https://axiom.co/careers/0123
+3/27/2026,Grafana Labs,Senior Software Engineer,Hybrid,Chicago IL,Applied,https://grafana.com/careers/4567
+3/30/2026,HashiCorp,Platform Engineer,Remote,,Rejected,https://hashicorp.com/careers/8901
+4/01/2026,Temporal,Distributed Systems Engineer,Remote,,Applied,https://temporal.io/careers/2345
+4/03/2026,CockroachDB,Database Engineer,Remote,New York NY,Interviewing,https://cockroachlabs.com/careers/6789
+4/05/2026,Sourcegraph,Software Engineer,Remote,,Accepted,https://sourcegraph.com/careers/0123

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,8 +1,8 @@
 export default function DashboardPage() {
   return (
     <div className="space-y-4">
-      <h1 className="text-[1.875rem] font-bold tracking-[-0.025em] text-[#111827]">Dashboard</h1>
-      <p className="text-sm font-medium text-[#4B5563]">
+      <h1 className="text-[1.875rem] font-bold tracking-[-0.025em] text-foreground">Dashboard</h1>
+      <p className="text-sm font-medium text-muted-foreground">
         Dashboard overview coming soon. This will show a summary of your job
         search activity.
       </p>

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,0 +1,11 @@
+export default function DashboardPage() {
+  return (
+    <div className="space-y-4">
+      <h1 className="text-[1.875rem] font-bold tracking-[-0.025em] text-[#111827]">Dashboard</h1>
+      <p className="text-sm font-medium text-[#4B5563]">
+        Dashboard overview coming soon. This will show a summary of your job
+        search activity.
+      </p>
+    </div>
+  );
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -49,38 +49,48 @@
 }
 
 :root {
-  --background: oklch(1 0 0);
-  --foreground: oklch(0.145 0 0);
-  --card: oklch(1 0 0);
-  --card-foreground: oklch(0.145 0 0);
-  --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.145 0 0);
-  --primary: oklch(0.205 0 0);
-  --primary-foreground: oklch(0.985 0 0);
-  --secondary: oklch(0.97 0 0);
-  --secondary-foreground: oklch(0.205 0 0);
-  --muted: oklch(0.97 0 0);
-  --muted-foreground: oklch(0.556 0 0);
-  --accent: oklch(0.97 0 0);
-  --accent-foreground: oklch(0.205 0 0);
-  --destructive: oklch(0.577 0.245 27.325);
-  --border: oklch(0.922 0 0);
-  --input: oklch(0.922 0 0);
-  --ring: oklch(0.708 0 0);
-  --chart-1: oklch(0.87 0 0);
-  --chart-2: oklch(0.556 0 0);
-  --chart-3: oklch(0.439 0 0);
-  --chart-4: oklch(0.371 0 0);
-  --chart-5: oklch(0.269 0 0);
-  --radius: 0.625rem;
-  --sidebar: oklch(0.985 0 0);
-  --sidebar-foreground: oklch(0.145 0 0);
-  --sidebar-primary: oklch(0.205 0 0);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.97 0 0);
-  --sidebar-accent-foreground: oklch(0.205 0 0);
-  --sidebar-border: oklch(0.922 0 0);
-  --sidebar-ring: oklch(0.708 0 0);
+  /* Surface / Background */
+  --background: #F9FAFB;
+  --foreground: #111827;
+  --card: #FFFFFF;
+  --card-foreground: #111827;
+  --popover: #FFFFFF;
+  --popover-foreground: #111827;
+  /* Primary (Brand): #1A56DB */
+  --primary: #1A56DB;
+  --primary-foreground: #FFFFFF;
+  /* Secondary */
+  --secondary: #F3F4F6;
+  --secondary-foreground: #111827;
+  /* Muted / Placeholder */
+  --muted: #F3F4F6;
+  --muted-foreground: #9CA3AF;
+  /* Accent */
+  --accent: #F3F4F6;
+  --accent-foreground: #111827;
+  /* Destructive (Error/Rejected) */
+  --destructive: #EF4444;
+  /* Borders & Dividers */
+  --border: #E5E7EB;
+  --input: #E5E7EB;
+  --ring: #1A56DB;
+  /* Charts */
+  --chart-1: #1A56DB;
+  --chart-2: #10B981;
+  --chart-3: #F59E0B;
+  --chart-4: #EF4444;
+  --chart-5: #6B7280;
+  /* Corner Radius: 8px */
+  --radius: 0.5rem;
+  /* Sidebar */
+  --sidebar: #F9FAFB;
+  --sidebar-foreground: #4B5563;
+  --sidebar-primary: #1A56DB;
+  --sidebar-primary-foreground: #FFFFFF;
+  --sidebar-accent: #EBF0FE;
+  --sidebar-accent-foreground: #1A56DB;
+  --sidebar-border: #E5E7EB;
+  --sidebar-ring: #1A56DB;
 }
 
 .dark {

--- a/src/app/insights/page.tsx
+++ b/src/app/insights/page.tsx
@@ -1,0 +1,11 @@
+export default function InsightsPage() {
+  return (
+    <div className="space-y-4">
+      <h1 className="text-[1.875rem] font-bold tracking-[-0.025em] text-[#111827]">Insights</h1>
+      <p className="text-sm font-medium text-[#4B5563]">
+        Insights and analytics coming soon. This will help you understand
+        patterns in your job search.
+      </p>
+    </div>
+  );
+}

--- a/src/app/insights/page.tsx
+++ b/src/app/insights/page.tsx
@@ -1,8 +1,8 @@
 export default function InsightsPage() {
   return (
     <div className="space-y-4">
-      <h1 className="text-[1.875rem] font-bold tracking-[-0.025em] text-[#111827]">Insights</h1>
-      <p className="text-sm font-medium text-[#4B5563]">
+      <h1 className="text-[1.875rem] font-bold tracking-[-0.025em] text-foreground">Insights</h1>
+      <p className="text-sm font-medium text-muted-foreground">
         Insights and analytics coming soon. This will help you understand
         patterns in your job search.
       </p>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,13 +1,11 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
-import Link from "next/link";
+import { Manrope, Geist_Mono } from "next/font/google";
 import { getOptionalSession, isAuthEnabled } from "@/lib/auth-optional";
-import { signOut } from "@/lib/auth";
-import { Button } from "@/components/ui/button";
+import { AppShell } from "@/components/layout/app-shell";
 import "./globals.css";
 
-const geistSans = Geist({
-  variable: "--font-geist-sans",
+const manrope = Manrope({
+  variable: "--font-sans",
   subsets: ["latin"],
 });
 
@@ -31,36 +29,15 @@ export default async function RootLayout({
   return (
     <html
       lang="en"
-      className={`${geistSans.variable} ${geistMono.variable} h-full antialiased`}
+      className={`${manrope.variable} ${geistMono.variable} h-full antialiased`}
     >
-      <body className="min-h-full flex flex-col">
-        <header className="border-b">
-          <div className="container mx-auto px-4 h-14 flex items-center justify-between">
-            <Link href="/" className="font-semibold text-lg">
-              Opportunity Tracker
-            </Link>
-            <div className="flex items-center gap-4">
-              {session?.user && (
-                <span className="text-sm text-muted-foreground">
-                  {session.user.name ?? session.user.email}
-                </span>
-              )}
-              {isAuthEnabled() && session?.user && (
-                <form
-                  action={async () => {
-                    "use server";
-                    await signOut();
-                  }}
-                >
-                  <Button variant="outline" size="sm" type="submit">
-                    Sign out
-                  </Button>
-                </form>
-              )}
-            </div>
-          </div>
-        </header>
-        <main className="flex-1 container mx-auto px-4 py-8">{children}</main>
+      <body className="h-full overflow-hidden">
+        <AppShell
+          user={session?.user ?? null}
+          authEnabled={isAuthEnabled()}
+        >
+          {children}
+        </AppShell>
       </body>
     </html>
   );

--- a/src/app/opportunities/[id]/edit/page.tsx
+++ b/src/app/opportunities/[id]/edit/page.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import { notFound } from "next/navigation";
 import { OpportunityForm } from "@/components/opportunity-form";
 import { getOpportunity } from "@/lib/actions/opportunities";
@@ -16,6 +17,22 @@ export default async function EditOpportunityPage({ params }: PageProps) {
 
   return (
     <div className="space-y-6">
+      <nav className="text-sm text-muted-foreground">
+        <span>Portfolio</span>
+        <span className="mx-1.5">&rsaquo;</span>
+        <Link href="/" className="hover:text-foreground">
+          Applications
+        </Link>
+        <span className="mx-1.5">&rsaquo;</span>
+        <Link
+          href={`/opportunities/${opportunity.id}`}
+          className="hover:text-foreground"
+        >
+          {opportunity.company}
+        </Link>
+        <span className="mx-1.5">&rsaquo;</span>
+        <span className="text-foreground font-medium">Edit</span>
+      </nav>
       <h1 className="text-2xl font-bold">
         Edit: {opportunity.company} — {opportunity.role}
       </h1>

--- a/src/app/opportunities/[id]/page.tsx
+++ b/src/app/opportunities/[id]/page.tsx
@@ -38,6 +38,18 @@ export default async function OpportunityDetailPage({ params }: PageProps) {
 
   return (
     <div className="space-y-6 max-w-2xl">
+      <nav className="text-sm text-muted-foreground">
+        <span>Portfolio</span>
+        <span className="mx-1.5">&rsaquo;</span>
+        <Link href="/" className="hover:text-foreground">
+          Applications
+        </Link>
+        <span className="mx-1.5">&rsaquo;</span>
+        <span className="text-foreground font-medium">
+          {opportunity.company}
+        </span>
+      </nav>
+
       <div className="flex items-center justify-between">
         <div className="space-y-1">
           <h1 className="text-2xl font-bold">{opportunity.company}</h1>

--- a/src/app/opportunities/new/page.tsx
+++ b/src/app/opportunities/new/page.tsx
@@ -1,8 +1,18 @@
+import Link from "next/link";
 import { OpportunityForm } from "@/components/opportunity-form";
 
 export default function NewOpportunityPage() {
   return (
     <div className="space-y-6">
+      <nav className="text-sm text-muted-foreground">
+        <span>Portfolio</span>
+        <span className="mx-1.5">&rsaquo;</span>
+        <Link href="/" className="hover:text-foreground">
+          Applications
+        </Link>
+        <span className="mx-1.5">&rsaquo;</span>
+        <span className="text-foreground font-medium">New</span>
+      </nav>
       <h1 className="text-2xl font-bold">Add Opportunity</h1>
       <OpportunityForm />
     </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import { Suspense } from "react";
+import { Plus } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { OpportunityTable } from "@/components/opportunity-table";
 import { StatusFilter } from "@/components/status-filter";
@@ -18,17 +19,36 @@ export default async function HomePage({ searchParams }: PageProps) {
 
   return (
     <div className="space-y-6">
-      <div className="flex items-center justify-between">
-        <h1 className="text-2xl font-bold">Opportunities</h1>
+      {/* Breadcrumb */}
+      <nav className="text-sm text-[#9CA3AF]">
+        <span>Portfolio</span>
+        <span className="mx-1.5">&rsaquo;</span>
+        <span className="text-primary font-medium">Applications</span>
+      </nav>
+
+      {/* Header */}
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h1 className="text-[1.875rem] font-bold tracking-[-0.025em] text-[#111827]">Applications</h1>
+          <p className="hidden sm:block text-sm font-medium text-[#4B5563] mt-1">
+            Track and manage your professional journey through active
+            opportunities and historical records.
+          </p>
+        </div>
         <Link href="/opportunities/new">
-          <Button>Add Opportunity</Button>
+          <Button className="gap-1.5">
+            <Plus className="size-4" />
+            Add Opportunity
+          </Button>
         </Link>
       </div>
 
+      {/* Filters */}
       <Suspense>
         <StatusFilter />
       </Suspense>
 
+      {/* Table */}
       <OpportunityTable opportunities={opportunities} />
     </div>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -20,7 +20,7 @@ export default async function HomePage({ searchParams }: PageProps) {
   return (
     <div className="space-y-6">
       {/* Breadcrumb */}
-      <nav className="text-sm text-[#9CA3AF]">
+      <nav className="text-sm text-muted-foreground">
         <span>Portfolio</span>
         <span className="mx-1.5">&rsaquo;</span>
         <span className="text-primary font-medium">Applications</span>
@@ -29,8 +29,8 @@ export default async function HomePage({ searchParams }: PageProps) {
       {/* Header */}
       <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
         <div>
-          <h1 className="text-[1.875rem] font-bold tracking-[-0.025em] text-[#111827]">Applications</h1>
-          <p className="hidden sm:block text-sm font-medium text-[#4B5563] mt-1">
+          <h1 className="text-[1.875rem] font-bold tracking-[-0.025em] text-foreground">Applications</h1>
+          <p className="hidden sm:block text-sm font-medium text-muted-foreground mt-1">
             Track and manage your professional journey through active
             opportunities and historical records.
           </p>

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1,8 +1,8 @@
 export default function SettingsPage() {
   return (
     <div className="space-y-4">
-      <h1 className="text-[1.875rem] font-bold tracking-[-0.025em] text-[#111827]">Settings</h1>
-      <p className="text-sm font-medium text-[#4B5563]">
+      <h1 className="text-[1.875rem] font-bold tracking-[-0.025em] text-foreground">Settings</h1>
+      <p className="text-sm font-medium text-muted-foreground">
         Settings coming soon. This will let you configure your account and
         preferences.
       </p>

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1,0 +1,11 @@
+export default function SettingsPage() {
+  return (
+    <div className="space-y-4">
+      <h1 className="text-[1.875rem] font-bold tracking-[-0.025em] text-[#111827]">Settings</h1>
+      <p className="text-sm font-medium text-[#4B5563]">
+        Settings coming soon. This will let you configure your account and
+        preferences.
+      </p>
+    </div>
+  );
+}

--- a/src/components/layout/app-shell.tsx
+++ b/src/components/layout/app-shell.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { useState } from "react";
+import { Sidebar } from "./sidebar";
+import { TopBar } from "./top-bar";
+
+interface AppShellProps {
+  children: React.ReactNode;
+  user: { name?: string | null; email?: string | null; image?: string | null } | null;
+  authEnabled: boolean;
+}
+
+export function AppShell({ children, user, authEnabled }: AppShellProps) {
+  const [collapsed, setCollapsed] = useState(false);
+  const [mobileOpen, setMobileOpen] = useState(false);
+
+  return (
+    <div className="flex h-full">
+      <Sidebar
+        collapsed={collapsed}
+        onToggle={() => setCollapsed((c) => !c)}
+        authEnabled={authEnabled}
+        mobileOpen={mobileOpen}
+        onMobileClose={() => setMobileOpen(false)}
+      />
+      <div className="flex flex-1 flex-col min-w-0">
+        <TopBar
+          user={user}
+          onMobileMenuClick={() => setMobileOpen(true)}
+        />
+        <main className="flex-1 overflow-y-auto p-4 md:p-6">
+          {children}
+        </main>
+      </div>
+    </div>
+  );
+}

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -1,0 +1,206 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import {
+  LayoutDashboard,
+  Briefcase,
+  BarChart3,
+  Archive,
+  Settings,
+  LogOut,
+  PanelLeftClose,
+  PanelLeftOpen,
+  X,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+import { signOutAction } from "@/lib/actions/auth";
+
+const navItems = [
+  { href: "/dashboard", label: "Dashboard", icon: LayoutDashboard },
+  { href: "/", label: "Applications", icon: Briefcase },
+  { href: "/insights", label: "Insights", icon: BarChart3 },
+  { href: "/?archived=true", label: "Archive", icon: Archive },
+];
+
+const bottomItems = [
+  { href: "/settings", label: "Settings", icon: Settings },
+];
+
+interface SidebarProps {
+  collapsed: boolean;
+  onToggle: () => void;
+  authEnabled: boolean;
+  mobileOpen: boolean;
+  onMobileClose: () => void;
+}
+
+function isActive(pathname: string, search: string, href: string) {
+  if (href === "/") {
+    return pathname === "/" && !search.includes("archived=true");
+  }
+  if (href === "/?archived=true") {
+    return search.includes("archived=true");
+  }
+  return pathname.startsWith(href);
+}
+
+function NavLink({
+  href,
+  label,
+  icon: Icon,
+  active,
+  collapsed,
+  onClick,
+}: {
+  href: string;
+  label: string;
+  icon: React.ComponentType<{ className?: string }>;
+  active: boolean;
+  collapsed: boolean;
+  onClick?: () => void;
+}) {
+  return (
+    <Link
+      href={href}
+      onClick={onClick}
+      title={collapsed ? label : undefined}
+      className={cn(
+        "relative flex items-center gap-3 rounded-lg px-3 py-2.5 text-[0.8125rem] font-semibold tracking-[0.025em] transition-colors",
+        active
+          ? "bg-sidebar-accent text-sidebar-accent-foreground"
+          : "text-sidebar-foreground hover:bg-sidebar-accent/50 hover:text-sidebar-accent-foreground",
+        collapsed && "justify-center px-2"
+      )}
+    >
+      {active && (
+        <span className="absolute left-0 top-1/2 -translate-y-1/2 h-6 w-0.5 rounded-r bg-sidebar-primary" />
+      )}
+      <Icon className="size-5 shrink-0" />
+      {!collapsed && <span>{label}</span>}
+    </Link>
+  );
+}
+
+export function Sidebar({
+  collapsed,
+  onToggle,
+  authEnabled,
+  mobileOpen,
+  onMobileClose,
+}: SidebarProps) {
+  const pathname = usePathname();
+  const search = typeof window !== "undefined" ? window.location.search : "";
+
+  const sidebarContent = (
+    <div className="flex h-full flex-col bg-sidebar text-sidebar-foreground">
+      {/* Logo */}
+      <div className="flex h-14 items-center border-b border-sidebar-border px-4">
+        <Link href="/" className="flex items-center gap-3" onClick={onMobileClose}>
+          <Briefcase className="size-6 shrink-0 text-primary" />
+          {!collapsed && (
+            <div className="flex flex-col">
+              <span className="text-sm font-semibold leading-tight">
+                Opportunity
+              </span>
+              <span className="text-xs text-sidebar-foreground/60 leading-tight">
+                Career Portfolio
+              </span>
+            </div>
+          )}
+        </Link>
+        {/* Mobile close button */}
+        <button
+          onClick={onMobileClose}
+          className="ml-auto md:hidden p-1 rounded-md hover:bg-sidebar-accent"
+        >
+          <X className="size-5" />
+        </button>
+      </div>
+
+      {/* Main nav */}
+      <nav className="flex-1 space-y-1 px-3 py-4">
+        {navItems.map((item) => (
+          <NavLink
+            key={item.href}
+            {...item}
+            active={isActive(pathname, search, item.href)}
+            collapsed={collapsed}
+            onClick={onMobileClose}
+          />
+        ))}
+      </nav>
+
+      {/* Bottom nav */}
+      <div className="space-y-1 border-t border-sidebar-border px-3 py-4">
+        {bottomItems.map((item) => (
+          <NavLink
+            key={item.href}
+            {...item}
+            active={pathname.startsWith(item.href)}
+            collapsed={collapsed}
+            onClick={onMobileClose}
+          />
+        ))}
+        {authEnabled && (
+          <form action={signOutAction}>
+            <button
+              type="submit"
+              title={collapsed ? "Logout" : undefined}
+              className={cn(
+                "flex w-full items-center gap-3 rounded-lg px-3 py-2 text-[0.8125rem] font-semibold tracking-[0.025em] text-sidebar-foreground transition-colors hover:bg-sidebar-accent/50 hover:text-sidebar-accent-foreground",
+                collapsed && "justify-center px-2"
+              )}
+            >
+              <LogOut className="size-5 shrink-0" />
+              {!collapsed && <span>Logout</span>}
+            </button>
+          </form>
+        )}
+
+        {/* Collapse toggle (desktop only) */}
+        <button
+          onClick={onToggle}
+          className="hidden md:flex w-full items-center gap-3 rounded-lg px-3 py-2 text-[0.8125rem] font-semibold tracking-[0.025em] text-sidebar-foreground transition-colors hover:bg-sidebar-accent/50 hover:text-sidebar-accent-foreground justify-center md:justify-start"
+          title={collapsed ? "Expand sidebar" : "Collapse sidebar"}
+        >
+          {collapsed ? (
+            <PanelLeftOpen className="size-5 shrink-0" />
+          ) : (
+            <>
+              <PanelLeftClose className="size-5 shrink-0" />
+              <span>Collapse</span>
+            </>
+          )}
+        </button>
+      </div>
+    </div>
+  );
+
+  return (
+    <>
+      {/* Desktop sidebar */}
+      <aside
+        className={cn(
+          "hidden md:block shrink-0 border-r border-sidebar-border transition-all duration-200",
+          collapsed ? "w-16" : "w-64"
+        )}
+      >
+        {sidebarContent}
+      </aside>
+
+      {/* Mobile overlay */}
+      {mobileOpen && (
+        <>
+          <div
+            className="fixed inset-0 z-40 bg-black/50 md:hidden"
+            onClick={onMobileClose}
+          />
+          <aside className="fixed inset-y-0 left-0 z-50 w-64 md:hidden">
+            {sidebarContent}
+          </aside>
+        </>
+      )}
+    </>
+  );
+}

--- a/src/components/layout/top-bar.tsx
+++ b/src/components/layout/top-bar.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { Menu, Search, Bell } from "lucide-react";
+import { Input } from "@/components/ui/input";
+
+interface TopBarProps {
+  user: { name?: string | null; email?: string | null; image?: string | null } | null;
+  onMobileMenuClick: () => void;
+}
+
+function UserAvatar({
+  user,
+}: {
+  user: { name?: string | null; image?: string | null };
+}) {
+  const initials = (user.name ?? "U")
+    .split(" ")
+    .map((n) => n[0])
+    .join("")
+    .slice(0, 2)
+    .toUpperCase();
+
+  if (user.image) {
+    return (
+      <img
+        src={user.image}
+        alt={user.name ?? "User"}
+        className="size-8 rounded-full"
+      />
+    );
+  }
+
+  return (
+    <div className="flex size-8 items-center justify-center rounded-full bg-primary text-primary-foreground text-xs font-medium">
+      {initials}
+    </div>
+  );
+}
+
+export function TopBar({ user, onMobileMenuClick }: TopBarProps) {
+  return (
+    <header className="flex h-14 shrink-0 items-center gap-4 border-b px-4 md:px-6">
+      {/* Mobile hamburger */}
+      <button
+        onClick={onMobileMenuClick}
+        className="md:hidden p-1 rounded-md hover:bg-accent"
+      >
+        <Menu className="size-5" />
+      </button>
+
+      {/* Search */}
+      <div className="flex-1 max-w-md">
+        <div className="relative">
+          <Search className="absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            placeholder="Search opportunities..."
+            className="pl-9 h-9 rounded-full bg-muted border-0"
+            readOnly
+          />
+        </div>
+      </div>
+
+      {/* Right side */}
+      <div className="ml-auto flex items-center gap-3">
+        <button className="relative p-2 rounded-md hover:bg-accent text-muted-foreground">
+          <Bell className="size-5" />
+        </button>
+
+        {user && (
+          <div className="flex items-center gap-2">
+            <UserAvatar user={user} />
+            <span className="hidden sm:block text-sm font-semibold text-[#111827]">
+              {user.name ?? user.email}
+            </span>
+          </div>
+        )}
+      </div>
+    </header>
+  );
+}

--- a/src/components/layout/top-bar.tsx
+++ b/src/components/layout/top-bar.tsx
@@ -69,7 +69,7 @@ export function TopBar({ user, onMobileMenuClick }: TopBarProps) {
         {user && (
           <div className="flex items-center gap-2">
             <UserAvatar user={user} />
-            <span className="hidden sm:block text-sm font-semibold text-[#111827]">
+            <span className="hidden sm:block text-sm font-semibold text-foreground">
               {user.name ?? user.email}
             </span>
           </div>

--- a/src/components/opportunity-table.tsx
+++ b/src/components/opportunity-table.tsx
@@ -1,6 +1,15 @@
 "use client";
 
 import Link from "next/link";
+import { useRouter } from "next/navigation";
+import {
+  MoreHorizontal,
+  Eye,
+  Pencil,
+  Archive,
+  Trash2,
+  Calendar,
+} from "lucide-react";
 import {
   Table,
   TableBody,
@@ -9,16 +18,156 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { StatusBadge } from "@/components/status-badge";
+import {
+  archiveOpportunity,
+  deleteOpportunity,
+} from "@/lib/actions/opportunities";
 import type { Opportunity } from "@/lib/db/schema";
-import type { Status, WorkMode } from "@/lib/constants";
-import { WORK_MODE_LABELS } from "@/lib/constants";
+import type { Status } from "@/lib/constants";
 
 interface OpportunityTableProps {
   opportunities: Opportunity[];
 }
 
+function formatDate(dateStr: string | null): string {
+  if (!dateStr) return "—";
+  const date = new Date(dateStr);
+  return date.toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+function formatShortDate(dateStr: string | null): string {
+  if (!dateStr) return "—";
+  const date = new Date(dateStr);
+  return date.toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+  });
+}
+
+function formatRelativeDate(dateStr: string | null): string {
+  if (!dateStr) return "—";
+  const date = new Date(dateStr);
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+
+  if (diffDays === 0) return "Today";
+  if (diffDays === 1) return "Yesterday";
+  if (diffDays < 7) return `${diffDays} days ago`;
+  if (diffDays < 30) {
+    const weeks = Math.floor(diffDays / 7);
+    return `${weeks} ${weeks === 1 ? "week" : "weeks"} ago`;
+  }
+  return formatDate(dateStr);
+}
+
+function ActionsMenu({
+  opportunityId,
+  router,
+}: {
+  opportunityId: string;
+  router: ReturnType<typeof useRouter>;
+}) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger className="p-1 rounded-md hover:bg-accent cursor-pointer">
+        <MoreHorizontal className="size-4" />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuItem
+          onClick={() => router.push(`/opportunities/${opportunityId}`)}
+        >
+          <Eye className="size-4 mr-2" />
+          View
+        </DropdownMenuItem>
+        <DropdownMenuItem
+          onClick={() =>
+            router.push(`/opportunities/${opportunityId}/edit`)
+          }
+        >
+          <Pencil className="size-4 mr-2" />
+          Edit
+        </DropdownMenuItem>
+        <DropdownMenuItem
+          onClick={() => archiveOpportunity(opportunityId)}
+        >
+          <Archive className="size-4 mr-2" />
+          Archive
+        </DropdownMenuItem>
+        <DropdownMenuItem
+          className="text-destructive"
+          onClick={() => deleteOpportunity(opportunityId)}
+        >
+          <Trash2 className="size-4 mr-2" />
+          Delete
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+function MobileCard({
+  opp,
+  router,
+}: {
+  opp: Opportunity;
+  router: ReturnType<typeof useRouter>;
+}) {
+  return (
+    <div className="bg-card rounded-lg border border-[#E5E7EB] p-4">
+      {/* Top row: Role + Status + Actions */}
+      <div className="flex items-start justify-between gap-2">
+        <Link
+          href={`/opportunities/${opp.id}`}
+          className="flex-1 min-w-0"
+        >
+          <div className="text-[0.9375rem] font-bold text-[#111827] leading-snug">
+            {opp.role}
+          </div>
+          <div className="text-sm font-medium text-[#4B5563] mt-0.5">
+            {opp.company}
+          </div>
+        </Link>
+        <div className="flex items-center gap-1.5 shrink-0">
+          <StatusBadge
+            status={opp.status as Status}
+            opportunityId={opp.id}
+          />
+          <ActionsMenu opportunityId={opp.id} router={router} />
+        </div>
+      </div>
+
+      {/* Divider */}
+      <div className="border-t border-[#E5E7EB] my-3" />
+
+      {/* Bottom row: Applied date + relative time */}
+      <div className="flex items-center justify-between text-[0.8125rem] font-medium text-[#4B5563]">
+        <div className="flex items-center gap-1.5">
+          <Calendar className="size-3.5 text-[#9CA3AF]" />
+          <span>Applied {formatShortDate(opp.appliedAt)}</span>
+        </div>
+        <span className="text-[#9CA3AF]">
+          {formatRelativeDate(opp.updatedAt)}
+        </span>
+      </div>
+    </div>
+  );
+}
+
 export function OpportunityTable({ opportunities }: OpportunityTableProps) {
+  const router = useRouter();
+
   if (opportunities.length === 0) {
     return (
       <div className="text-center py-12 text-muted-foreground">
@@ -33,50 +182,62 @@ export function OpportunityTable({ opportunities }: OpportunityTableProps) {
   }
 
   return (
-    <div className="border rounded-lg">
-      <Table>
-        <TableHeader>
-          <TableRow>
-            <TableHead>Company</TableHead>
-            <TableHead>Role</TableHead>
-            <TableHead>Status</TableHead>
-            <TableHead>Location</TableHead>
-            <TableHead>Applied</TableHead>
-          </TableRow>
-        </TableHeader>
-        <TableBody>
-          {opportunities.map((opp) => (
-            <TableRow key={opp.id}>
-              <TableCell className="font-medium">
-                <Link
-                  href={`/opportunities/${opp.id}`}
-                  className="hover:underline"
-                >
-                  {opp.company}
-                </Link>
-              </TableCell>
-              <TableCell>{opp.role}</TableCell>
-              <TableCell>
-                <StatusBadge
-                  status={opp.status as Status}
-                  opportunityId={opp.id}
-                />
-              </TableCell>
-              <TableCell className="text-muted-foreground">
-                {[
-                  opp.workMode ? WORK_MODE_LABELS[opp.workMode as WorkMode] : null,
-                  opp.location,
-                ]
-                  .filter(Boolean)
-                  .join(" · ") || "—"}
-              </TableCell>
-              <TableCell className="text-muted-foreground">
-                {opp.appliedAt ?? "—"}
-              </TableCell>
+    <>
+      {/* Mobile: Card list */}
+      <div className="flex flex-col gap-3 md:hidden">
+        {opportunities.map((opp) => (
+          <MobileCard key={opp.id} opp={opp} router={router} />
+        ))}
+      </div>
+
+      {/* Desktop: Table */}
+      <div className="hidden md:block bg-card border rounded-lg">
+        <Table>
+          <TableHeader className="bg-[#F9FAFB]">
+            <TableRow className="hover:bg-transparent border-b border-[#E5E7EB]">
+              <TableHead>Company & Role</TableHead>
+              <TableHead>Status</TableHead>
+              <TableHead>Applied Date</TableHead>
+              <TableHead>Last Contact</TableHead>
+              <TableHead className="w-12">Actions</TableHead>
             </TableRow>
-          ))}
-        </TableBody>
-      </Table>
-    </div>
+          </TableHeader>
+          <TableBody>
+            {opportunities.map((opp) => (
+              <TableRow key={opp.id}>
+                <TableCell className="py-4">
+                  <Link
+                    href={`/opportunities/${opp.id}`}
+                    className="hover:underline"
+                  >
+                    <div className="text-sm font-semibold text-[#111827]">
+                      {opp.company}
+                    </div>
+                    <div className="text-sm font-medium text-[#4B5563]">
+                      {opp.role}
+                    </div>
+                  </Link>
+                </TableCell>
+                <TableCell>
+                  <StatusBadge
+                    status={opp.status as Status}
+                    opportunityId={opp.id}
+                  />
+                </TableCell>
+                <TableCell className="text-sm font-medium text-[#4B5563]">
+                  {formatDate(opp.appliedAt)}
+                </TableCell>
+                <TableCell className="text-sm font-medium text-[#4B5563]">
+                  {formatRelativeDate(opp.updatedAt)}
+                </TableCell>
+                <TableCell>
+                  <ActionsMenu opportunityId={opp.id} router={router} />
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+    </>
   );
 }

--- a/src/components/opportunity-table.tsx
+++ b/src/components/opportunity-table.tsx
@@ -125,17 +125,17 @@ function MobileCard({
   router: ReturnType<typeof useRouter>;
 }) {
   return (
-    <div className="bg-card rounded-lg border border-[#E5E7EB] p-4">
+    <div className="bg-card rounded-lg border border-border p-4">
       {/* Top row: Role + Status + Actions */}
       <div className="flex items-start justify-between gap-2">
         <Link
           href={`/opportunities/${opp.id}`}
           className="flex-1 min-w-0"
         >
-          <div className="text-[0.9375rem] font-bold text-[#111827] leading-snug">
+          <div className="text-[0.9375rem] font-bold text-foreground leading-snug">
             {opp.role}
           </div>
-          <div className="text-sm font-medium text-[#4B5563] mt-0.5">
+          <div className="text-sm font-medium text-muted-foreground mt-0.5">
             {opp.company}
           </div>
         </Link>
@@ -149,15 +149,15 @@ function MobileCard({
       </div>
 
       {/* Divider */}
-      <div className="border-t border-[#E5E7EB] my-3" />
+      <div className="border-t border-border my-3" />
 
       {/* Bottom row: Applied date + relative time */}
-      <div className="flex items-center justify-between text-[0.8125rem] font-medium text-[#4B5563]">
+      <div className="flex items-center justify-between text-[0.8125rem] font-medium text-muted-foreground">
         <div className="flex items-center gap-1.5">
-          <Calendar className="size-3.5 text-[#9CA3AF]" />
+          <Calendar className="size-3.5 text-muted-foreground" />
           <span>Applied {formatShortDate(opp.appliedAt)}</span>
         </div>
-        <span className="text-[#9CA3AF]">
+        <span className="text-muted-foreground">
           {formatRelativeDate(opp.updatedAt)}
         </span>
       </div>
@@ -193,8 +193,8 @@ export function OpportunityTable({ opportunities }: OpportunityTableProps) {
       {/* Desktop: Table */}
       <div className="hidden md:block bg-card border rounded-lg">
         <Table>
-          <TableHeader className="bg-[#F9FAFB]">
-            <TableRow className="hover:bg-transparent border-b border-[#E5E7EB]">
+          <TableHeader className="bg-background">
+            <TableRow className="hover:bg-transparent border-b border-border">
               <TableHead>Company & Role</TableHead>
               <TableHead>Status</TableHead>
               <TableHead>Applied Date</TableHead>
@@ -210,10 +210,10 @@ export function OpportunityTable({ opportunities }: OpportunityTableProps) {
                     href={`/opportunities/${opp.id}`}
                     className="hover:underline"
                   >
-                    <div className="text-sm font-semibold text-[#111827]">
+                    <div className="text-sm font-semibold text-foreground">
                       {opp.company}
                     </div>
-                    <div className="text-sm font-medium text-[#4B5563]">
+                    <div className="text-sm font-medium text-muted-foreground">
                       {opp.role}
                     </div>
                   </Link>
@@ -224,10 +224,10 @@ export function OpportunityTable({ opportunities }: OpportunityTableProps) {
                     opportunityId={opp.id}
                   />
                 </TableCell>
-                <TableCell className="text-sm font-medium text-[#4B5563]">
+                <TableCell className="text-sm font-medium text-muted-foreground">
                   {formatDate(opp.appliedAt)}
                 </TableCell>
-                <TableCell className="text-sm font-medium text-[#4B5563]">
+                <TableCell className="text-sm font-medium text-muted-foreground">
                   {formatRelativeDate(opp.updatedAt)}
                 </TableCell>
                 <TableCell>

--- a/src/components/status-badge.tsx
+++ b/src/components/status-badge.tsx
@@ -24,7 +24,7 @@ export function StatusBadge({
   const badge = (
     <Badge
       variant="outline"
-      className={`${STATUS_COLORS[status]} border-0 cursor-pointer`}
+      className={`${STATUS_COLORS[status]} border-0 cursor-pointer text-[0.75rem] uppercase tracking-wide font-bold`}
     >
       {STATUS_LABELS[status]}
     </Badge>

--- a/src/components/status-filter.tsx
+++ b/src/components/status-filter.tsx
@@ -1,11 +1,12 @@
 "use client";
 
 import { useRouter, useSearchParams } from "next/navigation";
+import { SlidersHorizontal } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { STATUSES, STATUS_LABELS, type Status } from "@/lib/constants";
 
 const filters: Array<{ value: Status | "all"; label: string }> = [
-  { value: "all", label: "All" },
+  { value: "all", label: "All Apps" },
   ...STATUSES.map((s) => ({ value: s, label: STATUS_LABELS[s] })),
 ];
 
@@ -25,17 +26,33 @@ export function StatusFilter() {
   }
 
   return (
-    <div className="flex flex-wrap gap-2">
-      {filters.map((f) => (
-        <Button
-          key={f.value}
-          variant={current === f.value ? "default" : "outline"}
-          size="sm"
-          onClick={() => setFilter(f.value)}
-        >
-          {f.label}
-        </Button>
-      ))}
+    <div className="flex items-center gap-2 overflow-x-auto">
+      <div className="flex flex-nowrap gap-2">
+        {filters.map((f) => (
+          <Button
+            key={f.value}
+            variant={current === f.value ? "default" : "secondary"}
+            size="sm"
+            className={`rounded-full shrink-0 font-semibold tracking-[0.025em] ${
+              current === f.value
+                ? "shadow-md"
+                : "text-[#4B5563]"
+            }`}
+            onClick={() => setFilter(f.value)}
+          >
+            {f.label}
+          </Button>
+        ))}
+      </div>
+      <Button
+        variant="secondary"
+        size="sm"
+        className="rounded-full shrink-0 gap-1.5 font-semibold tracking-[0.025em] text-[#4B5563]"
+        disabled
+      >
+        <SlidersHorizontal className="size-3.5" />
+        More Filters
+      </Button>
     </div>
   );
 }

--- a/src/components/status-filter.tsx
+++ b/src/components/status-filter.tsx
@@ -36,7 +36,7 @@ export function StatusFilter() {
             className={`rounded-full shrink-0 font-semibold tracking-[0.025em] ${
               current === f.value
                 ? "shadow-md"
-                : "text-[#4B5563]"
+                : "text-muted-foreground"
             }`}
             onClick={() => setFilter(f.value)}
           >
@@ -47,7 +47,7 @@ export function StatusFilter() {
       <Button
         variant="secondary"
         size="sm"
-        className="rounded-full shrink-0 gap-1.5 font-semibold tracking-[0.025em] text-[#4B5563]"
+        className="rounded-full shrink-0 gap-1.5 font-semibold tracking-[0.025em] text-muted-foreground"
         disabled
       >
         <SlidersHorizontal className="size-3.5" />

--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -70,7 +70,7 @@ function TableHead({ className, ...props }: React.ComponentProps<"th">) {
     <th
       data-slot="table-head"
       className={cn(
-        "h-10 px-2 text-left align-middle font-semibold whitespace-nowrap text-[#4B5563] text-[0.8125rem] tracking-[0.025em] [&:has([role=checkbox])]:pr-0",
+        "h-10 px-2 text-left align-middle font-semibold whitespace-nowrap text-muted-foreground text-[0.8125rem] tracking-[0.025em] [&:has([role=checkbox])]:pr-0",
         className
       )}
       {...props}

--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -70,7 +70,7 @@ function TableHead({ className, ...props }: React.ComponentProps<"th">) {
     <th
       data-slot="table-head"
       className={cn(
-        "h-10 px-2 text-left align-middle font-medium whitespace-nowrap text-foreground [&:has([role=checkbox])]:pr-0",
+        "h-10 px-2 text-left align-middle font-semibold whitespace-nowrap text-[#4B5563] text-[0.8125rem] tracking-[0.025em] [&:has([role=checkbox])]:pr-0",
         className
       )}
       {...props}

--- a/src/lib/actions/auth.ts
+++ b/src/lib/actions/auth.ts
@@ -1,0 +1,7 @@
+"use server";
+
+import { signOut } from "@/lib/auth";
+
+export async function signOutAction() {
+  await signOut();
+}

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -21,13 +21,13 @@ export const STATUS_LABELS: Record<Status, string> = {
 };
 
 export const STATUS_COLORS: Record<Status, string> = {
-  saved: "bg-gray-100 text-gray-800",
-  applied: "bg-blue-100 text-blue-800",
-  interviewing: "bg-yellow-100 text-yellow-800",
-  offered: "bg-green-100 text-green-800",
-  rejected: "bg-red-100 text-red-800",
-  withdrawn: "bg-orange-100 text-orange-800",
-  accepted: "bg-emerald-100 text-emerald-800",
+  saved: "bg-[#F3F4F6] text-[#6B7280]",
+  applied: "bg-[#F3F4F6] text-[#6B7280]",
+  interviewing: "bg-[#FEF3C7] text-[#F59E0B]",
+  offered: "bg-[#D1FAE5] text-[#10B981]",
+  rejected: "bg-[#FEE2E2] text-[#EF4444]",
+  withdrawn: "bg-[#FEF3C7] text-[#D97706]",
+  accepted: "bg-[#D1FAE5] text-[#059669]",
 };
 
 export const WORK_MODES = ["remote", "hybrid", "onsite"] as const;


### PR DESCRIPTION
## Summary

- Replaces the single-column header layout with a two-pane design: collapsible left sidebar + top bar with search, notifications, and user avatar
- Responsive mobile view with overlay drawer sidebar and card-based opportunity list (no horizontal scrolling)
- Design system updated to Google Stitch spec: Manrope font, `#1A56DB` blue primary, proper text hierarchy, 8px radius, status accent colors
- Stub pages added for Dashboard, Insights, and Settings
- Sample data CSV (28 opportunities) with README instructions for loading

## Changes

**New components:** `app-shell.tsx`, `sidebar.tsx`, `top-bar.tsx` (in `src/components/layout/`)

**Redesigned:** opportunity table (combined Company & Role column, actions dropdown, mobile card view), status filter (pill style with shadow), status badges (Stitch colors)

**Updated:** root layout, all page files (breadcrumbs), globals.css (full theme), constants.ts (status colors), next.config.ts (dev indicator position)

## Test plan

- [ ] `npm run dev` — verify two-pane layout renders correctly
- [ ] Toggle sidebar collapse on desktop
- [ ] Resize to mobile — verify drawer sidebar and card layout
- [ ] Click all nav items (Dashboard, Applications, Insights, Archive, Settings)
- [ ] Filter by status using pills
- [ ] Use actions menu (View, Edit, Archive, Delete) on an opportunity
- [ ] Load sample data: `npm run import -- scripts/sample-data.csv local-dev-user`
- [ ] `npm run build` — verify clean build

🤖 Generated with [Claude Code](https://claude.com/claude-code)