### PR TITLE
Add AI job posting parser with Firecrawl URL autofill

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,3 +14,20 @@ ALLOWED_USERS=
 # Sign up at https://turso.tech and create a database
 TURSO_DATABASE_URL=
 TURSO_AUTH_TOKEN=
+
+# Optional AI job posting parser
+# Supported providers: openai, anthropic, google
+AI_PROVIDER=
+AI_MODEL=
+AI_PARSE_TIMEOUT_MS=30000
+AI_PARSER_DEBUG=false
+OPENAI_API_KEY=
+ANTHROPIC_API_KEY=
+GOOGLE_GENERATIVE_AI_API_KEY=
+
+# Optional Firecrawl URL parsing
+FIRECRAWL_API_KEY=
+FIRECRAWL_API_URL=https://api.firecrawl.dev/v2
+FIRECRAWL_TIMEOUT_MS=30000
+FIRECRAWL_MAX_AGE_MS=0
+FIRECRAWL_PROXY=auto

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,3 +50,22 @@ TURSO_DATABASE_URL=<url> TURSO_AUTH_TOKEN=<token> npm run db:push
 ## GitHub Issues
 
 Feature backlog is tracked in GitHub Issues: https://github.com/zachradtka/opportunity-tracker/issues
+
+## AI Parsing
+
+- URL parsing uses Firecrawl when `FIRECRAWL_API_KEY` is configured
+- Pasted-text parsing uses the configured AI provider when `AI_PROVIDER` is set to a supported provider and the matching API key is present
+- Supported providers today: `openai`, `anthropic`, `google`
+- Optional: set `AI_MODEL` to override the default model for the selected provider
+- Optional: set `AI_PARSE_TIMEOUT_MS` to control how long a parse call can run before it fails
+- Optional: set `AI_PARSER_DEBUG=true` for verbose server logs while debugging parser behavior locally
+- Optional Firecrawl settings:
+  - `FIRECRAWL_API_URL` defaults to `https://api.firecrawl.dev/v2`
+  - `FIRECRAWL_TIMEOUT_MS` controls the Firecrawl scrape timeout
+  - `FIRECRAWL_MAX_AGE_MS` controls Firecrawl caching
+  - `FIRECRAWL_PROXY` can be `basic`, `enhanced`, or `auto`
+- Required keys by provider:
+  - `OPENAI_API_KEY` when `AI_PROVIDER=openai`
+  - `ANTHROPIC_API_KEY` when `AI_PROVIDER=anthropic`
+  - `GOOGLE_GENERATIVE_AI_API_KEY` when `AI_PROVIDER=google`
+- When neither Firecrawl nor an AI provider is configured, the opportunity form renders exactly like the non-AI version

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,12 @@
       "name": "opportunity-tracker",
       "version": "0.1.0",
       "dependencies": {
+        "@ai-sdk/anthropic": "^3.0.67",
+        "@ai-sdk/google": "^3.0.59",
+        "@ai-sdk/openai": "^3.0.51",
         "@base-ui/react": "^1.3.0",
         "@libsql/client": "^0.17.2",
+        "ai": "^6.0.149",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "drizzle-orm": "^0.45.2",
@@ -37,6 +41,100 @@
         "tailwindcss": "^4",
         "tsx": "^4.21.0",
         "typescript": "^5"
+      }
+    },
+    "node_modules/@ai-sdk/anthropic": {
+      "version": "3.0.67",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-3.0.67.tgz",
+      "integrity": "sha512-FFX4P5Fd6lcQJc2OLngZQkbbJHa0IDDZi087Edb8qRZx6h90krtM61ArbMUL8us/7ZUwojCXnyJ/wQ2Eflx2jQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.23"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/gateway": {
+      "version": "3.0.91",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.91.tgz",
+      "integrity": "sha512-J39Dh6Gyg6HjG3A7OFKnJMp3QyZ3Eex+XDiX8aFBdRwwZm3jGWaMhkCxQPH7yiQ9kRiErZwHXX/Oexx4SyGGGA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.23",
+        "@vercel/oidc": "3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/google": {
+      "version": "3.0.59",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/google/-/google-3.0.59.tgz",
+      "integrity": "sha512-N5pyd6xSIIguG45kM/hvWdTrmudOY/iZ07DZu12K5q/NSeapQQFOYg+3DRKONzS9+FESLugjjzFrzfA24sQ6lw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.23"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/openai": {
+      "version": "3.0.51",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-3.0.51.tgz",
+      "integrity": "sha512-qBgDOC+vlXwLFbZ3UoKx3T8VFyul3K39JNyW6E4XnOnzLT4Mlhb0GeDC06RvYqwGWOQFBQNLe/vegOMVtNpl5g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.23"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/provider": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.8.tgz",
+      "integrity": "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ai-sdk/provider-utils": {
+      "version": "4.0.23",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.23.tgz",
+      "integrity": "sha512-z8GlDaCmRSDlqkMF2f4/RFgWxdarvIbyuk+m6WXT1LYgsnGiXRJGTD2Z1+SDl3LqtFuRtGX1aghYvQLoHL/9pg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@standard-schema/spec": "^1.1.0",
+        "eventsource-parser": "^3.0.6"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -3016,6 +3114,15 @@
       "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
       "license": "MIT"
     },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/@panva/hkdf": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@panva/hkdf/-/hkdf-1.2.1.tgz",
@@ -3049,6 +3156,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
     },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
@@ -4064,6 +4177,15 @@
         "win32"
       ]
     },
+    "node_modules/@vercel/oidc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.1.0.tgz",
+      "integrity": "sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
     "node_modules/accepts": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
@@ -4108,6 +4230,24 @@
       "license": "MIT",
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/ai": {
+      "version": "6.0.149",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.149.tgz",
+      "integrity": "sha512-3asRb/m3ZGH7H4+VTuTgj8eQYJZ9IJUmV0ljLslY92mQp6Zj+NVn4SmFj0TBr2Y/wFBWC3xgn++47tSGOXxdbw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/gateway": "3.0.91",
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.23",
+        "@opentelemetry/api": "1.9.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/ajv": {
@@ -7883,6 +8023,12 @@
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "license": "MIT"
+    },
+    "node_modules/json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+      "license": "(AFL-2.1 OR BSD-3-Clause)"
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",

--- a/package.json
+++ b/package.json
@@ -13,8 +13,12 @@
     "import": "tsx scripts/import-csv.ts"
   },
   "dependencies": {
+    "@ai-sdk/anthropic": "^3.0.67",
+    "@ai-sdk/google": "^3.0.59",
+    "@ai-sdk/openai": "^3.0.51",
     "@base-ui/react": "^1.3.0",
     "@libsql/client": "^0.17.2",
+    "ai": "^6.0.149",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "drizzle-orm": "^0.45.2",

--- a/src/app/opportunities/[id]/edit/page.tsx
+++ b/src/app/opportunities/[id]/edit/page.tsx
@@ -36,7 +36,12 @@ export default async function EditOpportunityPage({ params }: PageProps) {
       <h1 className="text-2xl font-bold">
         Edit: {opportunity.company} — {opportunity.role}
       </h1>
-      <OpportunityForm opportunity={opportunity} />
+      <OpportunityForm
+        opportunity={opportunity}
+        aiEnabled={false}
+        urlAutofillEnabled={false}
+        textAutofillEnabled={false}
+      />
     </div>
   );
 }

--- a/src/app/opportunities/new/page.tsx
+++ b/src/app/opportunities/new/page.tsx
@@ -1,5 +1,7 @@
 import Link from "next/link";
 import { OpportunityForm } from "@/components/opportunity-form";
+import { isAiParsingEnabled } from "@/lib/ai";
+import { isFirecrawlEnabled } from "@/lib/firecrawl";
 
 export default function NewOpportunityPage() {
   return (
@@ -14,7 +16,11 @@ export default function NewOpportunityPage() {
         <span className="text-foreground font-medium">Create Opportunity</span>
       </nav>
       <h1 className="text-2xl font-bold">Create Opportunity</h1>
-      <OpportunityForm />
+      <OpportunityForm
+        aiEnabled={isAiParsingEnabled() || isFirecrawlEnabled()}
+        urlAutofillEnabled={isFirecrawlEnabled()}
+        textAutofillEnabled={isAiParsingEnabled()}
+      />
     </div>
   );
 }

--- a/src/components/opportunity-form.tsx
+++ b/src/components/opportunity-form.tsx
@@ -1,7 +1,16 @@
 "use client";
 
-import { useActionState, useEffect, useState, useCallback, useRef } from "react";
+import {
+  useActionState,
+  useEffect,
+  useState,
+  useCallback,
+  useRef,
+  useTransition,
+  useMemo,
+} from "react";
 import { useRouter } from "next/navigation";
+import { LoaderCircle } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -30,15 +39,26 @@ import {
   type OpportunityFormState,
   type ValidatableField,
 } from "@/lib/validations/opportunity";
+import { parseJobPosting } from "@/lib/actions/parse-job-posting";
+import type { ParsedJobPosting } from "@/lib/validations/parse-job-posting";
 
 interface OpportunityFormProps {
   opportunity?: Opportunity;
+  aiEnabled?: boolean;
+  urlAutofillEnabled?: boolean;
+  textAutofillEnabled?: boolean;
 }
 
-export function OpportunityForm({ opportunity }: OpportunityFormProps) {
+export function OpportunityForm({
+  opportunity,
+  aiEnabled = false,
+  urlAutofillEnabled = false,
+  textAutofillEnabled = false,
+}: OpportunityFormProps) {
   const router = useRouter();
   const isEditing = !!opportunity;
   const formRef = useRef<HTMLFormElement>(null);
+  const [isParsing, startParsing] = useTransition();
 
   // Controlled form values
   const [values, setValues] = useState({
@@ -63,6 +83,11 @@ export function OpportunityForm({ opportunity }: OpportunityFormProps) {
   });
 
   const [fieldErrors, setFieldErrors] = useState<Record<string, string | null>>({});
+  const [aiInputMode, setAiInputMode] = useState<"url" | "text">(
+    urlAutofillEnabled ? "url" : "text"
+  );
+  const [aiInputValue, setAiInputValue] = useState("");
+  const [aiError, setAiError] = useState<string | null>(null);
 
   const boundUpdateAction = opportunity
     ? updateOpportunity.bind(null, opportunity.id)
@@ -82,17 +107,20 @@ export function OpportunityForm({ opportunity }: OpportunityFormProps) {
   const formAction = isEditing ? updateAction : createAction;
   const pending = isEditing ? updatePending : createPending;
 
-  // Merge server errors into field errors when they come back
-  useEffect(() => {
-    if (state.errors) {
-      const serverErrors: Record<string, string | null> = {};
-      for (const [key, messages] of Object.entries(state.errors)) {
-        if (messages && messages.length > 0) {
-          serverErrors[key] = messages[0];
-        }
-      }
-      setFieldErrors((prev) => ({ ...prev, ...serverErrors }));
+  const serverFieldErrors = useMemo(() => {
+    const next: Record<string, string | null> = {};
+
+    if (!state.errors) {
+      return next;
     }
+
+    for (const [key, messages] of Object.entries(state.errors)) {
+      if (messages && messages.length > 0) {
+        next[key] = messages[0];
+      }
+    }
+
+    return next;
   }, [state.errors]);
 
   // Navigate on success
@@ -151,14 +179,129 @@ export function OpportunityForm({ opportunity }: OpportunityFormProps) {
   );
 
   const getError = (field: string): string | null => {
-    return fieldErrors[field] ?? null;
+    return fieldErrors[field] ?? serverFieldErrors[field] ?? null;
   };
+
+  const applyParsedValues = useCallback((parsed: ParsedJobPosting) => {
+    setValues((prev) => ({
+      ...prev,
+      company: parsed.company ?? "",
+      role: parsed.role ?? "",
+      department: parsed.department ?? "",
+      jobId: parsed.jobId ?? "",
+      employmentType: parsed.employmentType ?? "",
+      experienceLevel: parsed.experienceLevel ?? "",
+      workMode: parsed.workMode ?? "",
+      location: parsed.location ?? "",
+      url: parsed.url ?? "",
+      salaryMin: parsed.salaryMin != null ? String(parsed.salaryMin) : "",
+      salaryMax: parsed.salaryMax != null ? String(parsed.salaryMax) : "",
+      contactName: parsed.contactName ?? "",
+      datePosted: parsed.datePosted ?? "",
+      jobDescription: parsed.jobDescription ?? "",
+      notes: parsed.notes ?? "",
+    }));
+  }, []);
+
+  const handleAutoFill = useCallback(() => {
+    setAiError(null);
+
+    startParsing(async () => {
+      const result = await parseJobPosting({
+        sourceType: aiInputMode,
+        value: aiInputValue,
+      });
+
+      if (result.error) {
+        setAiError(result.error);
+        return;
+      }
+
+      if (!result.data) {
+        setAiError("Couldn't parse that posting right now. Please try again.");
+        return;
+      }
+
+      applyParsedValues(result.data);
+    });
+  }, [aiInputMode, aiInputValue, applyParsedValues]);
 
   return (
     <form ref={formRef} action={formAction} className="space-y-6 max-w-2xl">
       {state.message && state.errors && (
         <div className="rounded-md bg-destructive/10 p-3 text-sm text-destructive">
           {state.message}
+        </div>
+      )}
+
+      {aiEnabled && !isEditing && (
+        <div className="space-y-4 rounded-2xl border border-border/70 bg-muted/40 p-4 sm:p-5">
+          <div className="space-y-1">
+            <h2 className="text-base font-semibold">Paste a posting to auto-fill with AI</h2>
+            <p className="text-sm text-muted-foreground">
+              {urlAutofillEnabled && textAutofillEnabled
+                ? "Drop in a job URL or paste the description text, then review the suggested fields before saving."
+                : urlAutofillEnabled
+                  ? "Drop in a job URL and we&apos;ll scrape the posting to suggest form values."
+                  : "Paste the description text, then review the suggested fields before saving."}
+            </p>
+          </div>
+
+          {aiInputMode === "url" && urlAutofillEnabled ? (
+            <div className="space-y-2">
+              <Label htmlFor="ai-url">Job Posting URL</Label>
+              <Input
+                id="ai-url"
+                value={aiInputValue}
+                onChange={(e) => setAiInputValue(e.target.value)}
+                placeholder="https://..."
+                disabled={isParsing}
+              />
+            </div>
+          ) : (
+            <div className="space-y-2">
+              <Label htmlFor="ai-text">Job Description Text</Label>
+              <Textarea
+                id="ai-text"
+                rows={8}
+                value={aiInputValue}
+                onChange={(e) => setAiInputValue(e.target.value)}
+                placeholder="Paste the job posting text here..."
+                className="resize-y"
+                disabled={isParsing}
+              />
+            </div>
+          )}
+
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            {urlAutofillEnabled && textAutofillEnabled ? (
+              <button
+                type="button"
+                className="w-fit text-sm text-primary underline-offset-4 hover:underline"
+                onClick={() => {
+                  setAiError(null);
+                  setAiInputValue("");
+                  setAiInputMode((prev) => (prev === "url" ? "text" : "url"));
+                }}
+              >
+                {aiInputMode === "url"
+                  ? "Or paste job description text"
+                  : "Or switch back to a job posting URL"}
+              </button>
+            ) : (
+              <div />
+            )}
+            <Button type="button" onClick={handleAutoFill} disabled={isParsing}>
+              {isParsing && <LoaderCircle className="animate-spin" />}
+              {isParsing ? "Auto-filling..." : "Auto-fill"}
+            </Button>
+          </div>
+
+          {aiError && (
+            <p className="rounded-md bg-destructive/10 p-3 text-sm text-destructive">
+              {aiError}
+            </p>
+          )}
         </div>
       )}
 

--- a/src/lib/actions/parse-job-posting.ts
+++ b/src/lib/actions/parse-job-posting.ts
@@ -1,0 +1,354 @@
+"use server";
+
+import { generateObject } from "ai";
+import * as z from "zod";
+import {
+  getAiLanguageModel,
+  getAiProviderConfig,
+  isAiParsingEnabled,
+} from "@/lib/ai";
+import { requireUserId } from "@/lib/auth-optional";
+import { getFirecrawlConfig, isFirecrawlEnabled } from "@/lib/firecrawl";
+import {
+  parsedJobPostingJsonSchema,
+  parsedJobPostingSchema,
+  type ParsedJobPosting,
+} from "@/lib/validations/parse-job-posting";
+
+type ParseJobPostingInput =
+  | { sourceType: "url"; value: string }
+  | { sourceType: "text"; value: string };
+
+export type ParseJobPostingResult =
+  | { data: ParsedJobPosting; error?: undefined }
+  | { data?: undefined; error: string };
+
+const DEFAULT_PARSE_TIMEOUT_MS = 30_000;
+const FIRECRAWL_EXCTRACTION_PROMPT = `
+Extract job posting details into structured data.
+
+Rules:
+- Only include fields you can infer from the page.
+- Leave fields undefined when they are unknown.
+- Use one of these exact values for workMode: remote, hybrid, onsite.
+- Use one of these exact values for employmentType: full-time, part-time, contract, internship.
+- Use one of these exact values for experienceLevel: intern, junior, mid, senior, staff, principal.
+- Use salaryMin and salaryMax as yearly whole-number amounts in USD when the posting gives a clear annual range.
+- Use datePosted in YYYY-MM-DD format only when the exact date is available.
+- Put the main job posting text in jobDescription when available.
+- Put useful extra context that does not fit elsewhere into notes.
+- Do not invent details.
+`;
+
+function buildPrompt(input: ParseJobPostingInput) {
+  return `
+${FIRECRAWL_EXCTRACTION_PROMPT}
+
+The user pasted the following raw job posting text. Extract as much structured data as you can:
+
+${input.value}
+`;
+}
+
+function hasMeaningfulParsedData(data: ParsedJobPosting) {
+  return Object.entries(data).some(([key, value]) => {
+    if (value == null) {
+      return false;
+    }
+
+    if (key === "url") {
+      return false;
+    }
+
+    if (typeof value === "string") {
+      return value.trim().length > 0;
+    }
+
+    return true;
+  });
+}
+
+function normalizeWhitespace(value?: string) {
+  return value?.replace(/\r\n/g, "\n").trim() || undefined;
+}
+
+function normalizeSalary(value?: number) {
+  if (value == null || !Number.isFinite(value)) {
+    return undefined;
+  }
+
+  const rounded = Math.round(value);
+  return rounded >= 0 ? rounded : undefined;
+}
+
+function getParseTimeoutMs() {
+  const rawValue = process.env.AI_PARSE_TIMEOUT_MS;
+
+  if (!rawValue) {
+    return DEFAULT_PARSE_TIMEOUT_MS;
+  }
+
+  const parsedValue = Number(rawValue);
+  return Number.isFinite(parsedValue) && parsedValue > 0
+    ? parsedValue
+    : DEFAULT_PARSE_TIMEOUT_MS;
+}
+
+function isParserDebugEnabled() {
+  return process.env.AI_PARSER_DEBUG === "true";
+}
+
+function logParserDebug(message: string, details?: Record<string, unknown>) {
+  if (!isParserDebugEnabled()) {
+    return;
+  }
+
+  console.log(`[ai-parser] ${message}`, details ?? {});
+}
+
+async function generateParsedTextPosting(input: Extract<ParseJobPostingInput, { sourceType: "text" }>) {
+  const result = await generateObject({
+    model: getAiLanguageModel(),
+    timeout: { totalMs: getParseTimeoutMs() },
+    schema: parsedJobPostingSchema,
+    schemaName: "parsed_job_posting",
+    schemaDescription: "Structured job posting details for an application tracker",
+    prompt: buildPrompt(input),
+  });
+
+  return result.object;
+}
+
+type FirecrawlScrapeResponse = {
+  success: boolean;
+  data?: {
+    json?: unknown;
+    warning?: string;
+    metadata?: {
+      title?: string;
+      statusCode?: number;
+      sourceURL?: string;
+      error?: string;
+    };
+  };
+};
+
+async function scrapeJobPostingWithFirecrawl(url: string): Promise<ParsedJobPosting> {
+  const config = getFirecrawlConfig();
+
+  if (!config) {
+    throw new Error("Firecrawl is not configured.");
+  }
+
+  const response = await fetch(`${config.apiUrl}/scrape`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${config.apiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      url,
+      onlyMainContent: true,
+      timeout: config.timeoutMs,
+      maxAge: config.maxAgeMs,
+      proxy: config.proxy,
+      blockAds: true,
+      removeBase64Images: true,
+      formats: [
+        {
+          type: "json",
+          prompt: FIRECRAWL_EXCTRACTION_PROMPT,
+          schema: parsedJobPostingJsonSchema,
+        },
+      ],
+    }),
+    cache: "no-store",
+  });
+
+  const payload = (await response.json()) as FirecrawlScrapeResponse;
+
+  if (!response.ok || !payload.success) {
+    throw new Error(
+      `Firecrawl scrape failed (${response.status}): ${
+        payload.data?.metadata?.error || "Unknown error"
+      }`
+    );
+  }
+
+  logParserDebug("Firecrawl scrape completed", {
+    warning: payload.data?.warning,
+    statusCode: payload.data?.metadata?.statusCode,
+    title: payload.data?.metadata?.title,
+    sourceURL: payload.data?.metadata?.sourceURL,
+  });
+
+  const parsed = parsedJobPostingSchema.safeParse(payload.data?.json ?? {});
+
+  if (!parsed.success) {
+    throw new Error(
+      `Firecrawl returned invalid structured data: ${z.prettifyError(parsed.error)}`
+    );
+  }
+
+  return parsed.data;
+}
+
+function normalizeParsedJobPosting(
+  data: ParsedJobPosting,
+  input: ParseJobPostingInput
+): ParsedJobPosting {
+  const normalized: ParsedJobPosting = {
+    ...data,
+    company: normalizeWhitespace(data.company),
+    role: normalizeWhitespace(data.role),
+    location: normalizeWhitespace(data.location),
+    salaryMin: normalizeSalary(data.salaryMin),
+    salaryMax: normalizeSalary(data.salaryMax),
+    department: normalizeWhitespace(data.department),
+    jobId: normalizeWhitespace(data.jobId),
+    contactName: normalizeWhitespace(data.contactName),
+    jobDescription: normalizeWhitespace(data.jobDescription),
+    notes: normalizeWhitespace(data.notes),
+  };
+
+  if (input.sourceType === "url") {
+    normalized.url = input.value;
+  }
+
+  if (input.sourceType === "text" && !normalized.jobDescription) {
+    normalized.jobDescription = normalizeWhitespace(input.value);
+  }
+
+  if (
+    normalized.salaryMin != null &&
+    normalized.salaryMax != null &&
+    normalized.salaryMin > normalized.salaryMax
+  ) {
+    [normalized.salaryMin, normalized.salaryMax] = [
+      normalized.salaryMax,
+      normalized.salaryMin,
+    ];
+  }
+
+  return normalized;
+}
+
+export async function parseJobPosting(
+  input: ParseJobPostingInput
+): Promise<ParseJobPostingResult> {
+  await requireUserId();
+
+  const value = input.value.trim();
+  const providerConfig = getAiProviderConfig();
+  const firecrawlConfig = getFirecrawlConfig();
+  const startedAt = Date.now();
+
+  if (!value) {
+    return {
+      error:
+        input.sourceType === "url"
+          ? "Paste a job posting URL to auto-fill the form."
+          : "Paste a job description to auto-fill the form.",
+    };
+  }
+
+  if (input.sourceType === "url") {
+    try {
+      new URL(value);
+    } catch {
+      return { error: "Enter a valid job posting URL." };
+    }
+  }
+
+  if (input.sourceType === "url" && !isFirecrawlEnabled()) {
+    return { error: "URL parsing is not configured." };
+  }
+
+  if (input.sourceType === "text" && !isAiParsingEnabled()) {
+    return { error: "Text parsing is not configured." };
+  }
+
+  try {
+    logParserDebug("Starting parse", {
+      provider:
+        input.sourceType === "url"
+          ? "firecrawl"
+          : providerConfig?.provider ?? "unknown",
+      model: input.sourceType === "text" ? providerConfig?.model ?? "unknown" : undefined,
+      sourceType: input.sourceType,
+      timeoutMs:
+        input.sourceType === "url"
+          ? firecrawlConfig?.timeoutMs
+          : getParseTimeoutMs(),
+      url: input.sourceType === "url" ? value : undefined,
+      textLength: input.sourceType === "text" ? value.length : undefined,
+    });
+
+    const parsed =
+      input.sourceType === "url"
+        ? await scrapeJobPostingWithFirecrawl(value)
+        : await generateParsedTextPosting({ ...input, value });
+    const data = normalizeParsedJobPosting(parsed, { ...input, value });
+    const durationMs = Date.now() - startedAt;
+
+    logParserDebug("Parse completed", {
+      provider:
+        input.sourceType === "url"
+          ? "firecrawl"
+          : providerConfig?.provider ?? "unknown",
+      sourceType: input.sourceType,
+      durationMs,
+      extractedFields: Object.keys(data).filter((key) => {
+        const field = data[key as keyof ParsedJobPosting];
+        return field != null && String(field).trim() !== "";
+      }),
+    });
+
+    if (!hasMeaningfulParsedData(data)) {
+      return {
+        error:
+          input.sourceType === "url"
+            ? "Couldn't parse that posting. Try pasting the job description text instead."
+            : "Couldn't parse that posting text. Please review it and fill the form manually.",
+      };
+    }
+
+    return { data };
+  } catch (error) {
+    const durationMs = Date.now() - startedAt;
+
+    console.error("Failed to parse job posting", {
+      provider:
+        input.sourceType === "url"
+          ? "firecrawl"
+          : providerConfig?.provider ?? "unknown",
+      model: input.sourceType === "text" ? providerConfig?.model ?? "unknown" : undefined,
+      sourceType: input.sourceType,
+      timeoutMs:
+        input.sourceType === "url"
+          ? firecrawlConfig?.timeoutMs
+          : getParseTimeoutMs(),
+      durationMs,
+      error,
+    });
+
+    const errorMessage =
+      error instanceof Error ? error.message.toLowerCase() : String(error).toLowerCase();
+
+    if (errorMessage.includes("timed out") || errorMessage.includes("abort")) {
+      return {
+        error:
+          input.sourceType === "url"
+            ? "URL parsing took too long. Try again or paste the job description text instead."
+            : "AI parsing took too long. Try pasting the job description text instead.",
+      };
+    }
+
+    return {
+      error:
+        input.sourceType === "url"
+          ? "Couldn't parse that posting. Try pasting the job description text instead."
+          : "Couldn't parse that posting text right now. Please try again or fill the form manually.",
+    };
+  }
+}

--- a/src/lib/actions/parse-job-posting.ts
+++ b/src/lib/actions/parse-job-posting.ts
@@ -40,6 +40,66 @@ Rules:
 - Do not invent details.
 `;
 
+// Validates URL for safe processing with Firecrawl (prevent SSRF by blocking localhost/private IPs)
+function validateJobPostingUrl(url: string): { valid: true } | { valid: false; error: string } {
+  let parsed: URL;
+
+  try {
+    parsed = new URL(url);
+  } catch {
+    return { valid: false, error: "Enter a valid job posting URL." };
+  }
+
+  const hostname = parsed.hostname || "";
+  const lowerHostname = hostname.toLowerCase();
+
+  // Block localhost and loopback addresses
+  if (
+    lowerHostname === "localhost" ||
+    lowerHostname === "127.0.0.1" ||
+    lowerHostname === "::1" ||
+    lowerHostname.startsWith("[::ffff:127.")
+  ) {
+    return { valid: false, error: "Cannot parse job postings from localhost." };
+  }
+
+  // Block private IP ranges
+  const ipMatch = hostname.match(
+    /^(10\.|172\.(1[6-9]|2[0-9]|3[01])\.|192\.168\.|fe80:|fc[0-9a-f]{2}:)/i
+  );
+  if (ipMatch) {
+    return { valid: false, error: "Cannot parse job postings from private IP addresses." };
+  }
+
+  // Block reserved IPs
+  const reservedIps = [
+    "0",
+    "255",
+    "169.254",
+    "224",
+    "225",
+    "226",
+    "227",
+    "228",
+    "229",
+    "230",
+    "231",
+    "232",
+    "233",
+    "234",
+    "235",
+    "236",
+    "237",
+    "238",
+    "239",
+  ];
+  if (reservedIps.some((ip) => hostname.startsWith(ip + "."))) {
+    return { valid: false, error: "Cannot parse job postings from reserved IP addresses." };
+  }
+
+  return { valid: true };
+}
+
 function buildPrompt(input: ParseJobPostingInput) {
   return `
 ${FIRECRAWL_EXCTRACTION_PROMPT}
@@ -69,7 +129,7 @@ function hasMeaningfulParsedData(data: ParsedJobPosting) {
 }
 
 function normalizeWhitespace(value?: string) {
-  return value?.replace(/\r\n/g, "\n").trim() || undefined;
+  return value?.replace(/\r\n/g, "\n").replace(/\s+/g, " ").trim() || undefined;
 }
 
 function normalizeSalary(value?: number) {
@@ -253,10 +313,9 @@ export async function parseJobPosting(
   }
 
   if (input.sourceType === "url") {
-    try {
-      new URL(value);
-    } catch {
-      return { error: "Enter a valid job posting URL." };
+    const urlValidation = validateJobPostingUrl(value);
+    if (!urlValidation.valid) {
+      return { error: urlValidation.error };
     }
   }
 
@@ -329,7 +388,7 @@ export async function parseJobPosting(
           ? firecrawlConfig?.timeoutMs
           : getParseTimeoutMs(),
       durationMs,
-      error,
+      errorMessage: error instanceof Error ? error.message : String(error),
     });
 
     const errorMessage =

--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -1,0 +1,65 @@
+import { anthropic } from "@ai-sdk/anthropic";
+import { google } from "@ai-sdk/google";
+import { openai } from "@ai-sdk/openai";
+
+const SUPPORTED_AI_PROVIDERS = ["anthropic", "google", "openai"] as const;
+
+type SupportedAiProvider = (typeof SUPPORTED_AI_PROVIDERS)[number];
+
+const DEFAULT_MODELS: Record<SupportedAiProvider, string> = {
+  anthropic: "claude-3-5-sonnet-latest",
+  google: "gemini-2.5-flash",
+  openai: "gpt-4.1-mini",
+};
+
+function getProviderKey(provider: SupportedAiProvider) {
+  switch (provider) {
+    case "anthropic":
+      return process.env.ANTHROPIC_API_KEY;
+    case "google":
+      return process.env.GOOGLE_GENERATIVE_AI_API_KEY;
+    case "openai":
+      return process.env.OPENAI_API_KEY;
+  }
+}
+
+export function getAiProviderConfig() {
+  const provider = process.env.AI_PROVIDER?.trim().toLowerCase();
+
+  if (!provider || !SUPPORTED_AI_PROVIDERS.includes(provider as SupportedAiProvider)) {
+    return null;
+  }
+
+  const typedProvider = provider as SupportedAiProvider;
+  const apiKey = getProviderKey(typedProvider);
+
+  if (!apiKey) {
+    return null;
+  }
+
+  return {
+    provider: typedProvider,
+    model: process.env.AI_MODEL?.trim() || DEFAULT_MODELS[typedProvider],
+  };
+}
+
+export function isAiParsingEnabled() {
+  return getAiProviderConfig() !== null;
+}
+
+export function getAiLanguageModel() {
+  const config = getAiProviderConfig();
+
+  if (!config) {
+    throw new Error("AI parsing is not configured.");
+  }
+
+  switch (config.provider) {
+    case "anthropic":
+      return anthropic(config.model);
+    case "google":
+      return google(config.model);
+    case "openai":
+      return openai(config.model);
+  }
+}

--- a/src/lib/firecrawl.ts
+++ b/src/lib/firecrawl.ts
@@ -1,0 +1,39 @@
+const DEFAULT_FIRECRAWL_API_URL = "https://api.firecrawl.dev/v2";
+const DEFAULT_FIRECRAWL_TIMEOUT_MS = 30_000;
+const DEFAULT_FIRECRAWL_MAX_AGE_MS = 0;
+
+export function getFirecrawlConfig() {
+  const apiKey = process.env.FIRECRAWL_API_KEY?.trim();
+
+  if (!apiKey) {
+    return null;
+  }
+
+  return {
+    apiKey,
+    apiUrl: process.env.FIRECRAWL_API_URL?.trim() || DEFAULT_FIRECRAWL_API_URL,
+    timeoutMs: parsePositiveInt(
+      process.env.FIRECRAWL_TIMEOUT_MS,
+      DEFAULT_FIRECRAWL_TIMEOUT_MS
+    ),
+    maxAgeMs: parseNonNegativeInt(
+      process.env.FIRECRAWL_MAX_AGE_MS,
+      DEFAULT_FIRECRAWL_MAX_AGE_MS
+    ),
+    proxy: process.env.FIRECRAWL_PROXY?.trim() || "auto",
+  };
+}
+
+export function isFirecrawlEnabled() {
+  return getFirecrawlConfig() !== null;
+}
+
+function parsePositiveInt(value: string | undefined, fallback: number) {
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function parseNonNegativeInt(value: string | undefined, fallback: number) {
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed >= 0 ? parsed : fallback;
+}

--- a/src/lib/validations/opportunity.ts
+++ b/src/lib/validations/opportunity.ts
@@ -155,25 +155,30 @@ export type OpportunityFormState = {
   message?: string;
 };
 
+function getOptionalFormValue(formData: FormData, key: string) {
+  const value = formData.get(key);
+  return value === null ? undefined : value;
+}
+
 export function parseFormData(formData: FormData) {
   return opportunitySchema.safeParse({
     company: formData.get("company"),
     role: formData.get("role"),
-    url: formData.get("url"),
-    status: formData.get("status"),
-    salaryMin: formData.get("salaryMin"),
-    salaryMax: formData.get("salaryMax"),
-    workMode: formData.get("workMode"),
-    location: formData.get("location"),
-    department: formData.get("department"),
-    employmentType: formData.get("employmentType"),
-    experienceLevel: formData.get("experienceLevel"),
-    jobId: formData.get("jobId"),
-    datePosted: formData.get("datePosted"),
-    contactName: formData.get("contactName"),
-    jobDescription: formData.get("jobDescription"),
-    notes: formData.get("notes"),
-    appliedAt: formData.get("appliedAt"),
-    respondedAt: formData.get("respondedAt"),
+    url: getOptionalFormValue(formData, "url"),
+    status: getOptionalFormValue(formData, "status"),
+    salaryMin: getOptionalFormValue(formData, "salaryMin"),
+    salaryMax: getOptionalFormValue(formData, "salaryMax"),
+    workMode: getOptionalFormValue(formData, "workMode"),
+    location: getOptionalFormValue(formData, "location"),
+    department: getOptionalFormValue(formData, "department"),
+    employmentType: getOptionalFormValue(formData, "employmentType"),
+    experienceLevel: getOptionalFormValue(formData, "experienceLevel"),
+    jobId: getOptionalFormValue(formData, "jobId"),
+    datePosted: getOptionalFormValue(formData, "datePosted"),
+    contactName: getOptionalFormValue(formData, "contactName"),
+    jobDescription: getOptionalFormValue(formData, "jobDescription"),
+    notes: getOptionalFormValue(formData, "notes"),
+    appliedAt: getOptionalFormValue(formData, "appliedAt"),
+    respondedAt: getOptionalFormValue(formData, "respondedAt"),
   });
 }

--- a/src/lib/validations/parse-job-posting.ts
+++ b/src/lib/validations/parse-job-posting.ts
@@ -1,0 +1,64 @@
+import * as z from "zod";
+import {
+  EMPLOYMENT_TYPES,
+  EXPERIENCE_LEVELS,
+  WORK_MODES,
+} from "@/lib/constants";
+
+function optionalTrimmedString() {
+  return z.preprocess((value) => {
+    if (typeof value !== "string") {
+      return value;
+    }
+
+    const trimmed = value.trim();
+    return trimmed === "" ? undefined : trimmed;
+  }, z.string().min(1).optional());
+}
+
+function optionalIsoDateString() {
+  return z.preprocess((value) => {
+    if (typeof value !== "string") {
+      return value;
+    }
+
+    const trimmed = value.trim();
+
+    if (trimmed === "") {
+      return undefined;
+    }
+
+    const isoMatch = trimmed.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+    if (isoMatch) {
+      return trimmed;
+    }
+
+    const parsed = new Date(trimmed);
+    if (Number.isNaN(parsed.getTime())) {
+      return trimmed;
+    }
+
+    return parsed.toISOString().slice(0, 10);
+  }, z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional());
+}
+
+export const parsedJobPostingSchema = z.object({
+  company: optionalTrimmedString(),
+  role: optionalTrimmedString(),
+  url: z.string().url().optional(),
+  workMode: z.enum(WORK_MODES).optional(),
+  location: optionalTrimmedString(),
+  salaryMin: z.number().optional(),
+  salaryMax: z.number().optional(),
+  department: optionalTrimmedString(),
+  employmentType: z.enum(EMPLOYMENT_TYPES).optional(),
+  experienceLevel: z.enum(EXPERIENCE_LEVELS).optional(),
+  jobId: optionalTrimmedString(),
+  datePosted: optionalIsoDateString(),
+  contactName: optionalTrimmedString(),
+  jobDescription: optionalTrimmedString(),
+  notes: optionalTrimmedString(),
+});
+
+export type ParsedJobPosting = z.infer<typeof parsedJobPostingSchema>;
+export const parsedJobPostingJsonSchema = z.toJSONSchema(parsedJobPostingSchema);


### PR DESCRIPTION
## Summary
- add AI autofill to the opportunity form with editable suggested values
- use Firecrawl structured scraping for URL input and provider-based parsing for pasted text
- add parser validation/normalization, config docs, and fixes for optional form field validation

## Testing
- npm run build
- npm run lint *(existing repo warnings only)*