### PR TITLE
Search opportunities by company, role, job ID, or location

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,14 +7,15 @@ import { listOpportunities } from "@/lib/actions/opportunities";
 import type { Status } from "@/lib/constants";
 
 interface PageProps {
-  searchParams: Promise<{ status?: string; archived?: string }>;
+  searchParams: Promise<{ status?: string; archived?: string; search?: string }>;
 }
 
 export default async function HomePage({ searchParams }: PageProps) {
   const params = await searchParams;
   const statusFilter = (params.status as Status | "all") ?? "all";
   const showArchived = params.archived === "true";
-  const opportunities = await listOpportunities(statusFilter, showArchived);
+  const search = params.search || undefined;
+  const opportunities = await listOpportunities(statusFilter, showArchived, search);
 
   return (
     <div className="space-y-6">

--- a/src/components/layout/top-bar.tsx
+++ b/src/components/layout/top-bar.tsx
@@ -98,6 +98,7 @@ export function TopBar({ user, onMobileMenuClick }: TopBarProps) {
           {value && (
             <button
               onClick={clearSearch}
+              aria-label="Clear search"
               className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
             >
               <X className="size-4" />

--- a/src/components/layout/top-bar.tsx
+++ b/src/components/layout/top-bar.tsx
@@ -1,6 +1,8 @@
 "use client";
 
-import { Menu, Search, Bell } from "lucide-react";
+import { useState, useEffect, useCallback } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { Menu, Search, Bell, X } from "lucide-react";
 import { Input } from "@/components/ui/input";
 
 interface TopBarProps {
@@ -38,6 +40,41 @@ function UserAvatar({
 }
 
 export function TopBar({ user, onMobileMenuClick }: TopBarProps) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const currentSearch = searchParams.get("search") ?? "";
+  const [value, setValue] = useState(currentSearch);
+
+  // Sync local state when URL param changes externally
+  useEffect(() => {
+    setValue(currentSearch);
+  }, [currentSearch]);
+
+  // Debounced navigation
+  useEffect(() => {
+    const trimmed = value.trim();
+    if (trimmed === currentSearch) return;
+
+    const timer = setTimeout(() => {
+      const params = new URLSearchParams(searchParams.toString());
+      if (trimmed) {
+        params.set("search", trimmed);
+      } else {
+        params.delete("search");
+      }
+      router.push(`/?${params.toString()}`);
+    }, 300);
+
+    return () => clearTimeout(timer);
+  }, [value, currentSearch, searchParams, router]);
+
+  const clearSearch = useCallback(() => {
+    setValue("");
+    const params = new URLSearchParams(searchParams.toString());
+    params.delete("search");
+    router.push(`/?${params.toString()}`);
+  }, [searchParams, router]);
+
   return (
     <header className="flex h-14 shrink-0 items-center gap-4 border-b px-4 md:px-6">
       {/* Mobile hamburger */}
@@ -54,9 +91,18 @@ export function TopBar({ user, onMobileMenuClick }: TopBarProps) {
           <Search className="absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
           <Input
             placeholder="Search opportunities..."
-            className="pl-9 h-9 rounded-full bg-muted border-0"
-            readOnly
+            className="pl-9 pr-9 h-9 rounded-full bg-muted border-0"
+            value={value}
+            onChange={(e) => setValue(e.target.value)}
           />
+          {value && (
+            <button
+              onClick={clearSearch}
+              className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+            >
+              <X className="size-4" />
+            </button>
+          )}
         </div>
       </div>
 

--- a/src/lib/actions/opportunities.ts
+++ b/src/lib/actions/opportunities.ts
@@ -2,7 +2,7 @@
 
 import { db } from "@/lib/db";
 import { opportunities, statusHistory } from "@/lib/db/schema";
-import { eq, desc, and, or, like } from "drizzle-orm";
+import { eq, desc, and, sql } from "drizzle-orm";
 import { nanoid } from "nanoid";
 import { revalidatePath } from "next/cache";
 import type { Status } from "@/lib/constants";
@@ -40,14 +40,10 @@ export async function listOpportunities(
   }
 
   if (search) {
-    const pattern = `%${search}%`;
+    const escaped = search.replace(/[%_\\]/g, "\\$&");
+    const pattern = `%${escaped}%`;
     conditions.push(
-      or(
-        like(opportunities.company, pattern),
-        like(opportunities.role, pattern),
-        like(opportunities.jobId, pattern),
-        like(opportunities.location, pattern)
-      )!
+      sql`(${opportunities.company} LIKE ${pattern} ESCAPE '\\' OR ${opportunities.role} LIKE ${pattern} ESCAPE '\\' OR ${opportunities.jobId} LIKE ${pattern} ESCAPE '\\' OR ${opportunities.location} LIKE ${pattern} ESCAPE '\\')`
     );
   }
 

--- a/src/lib/actions/opportunities.ts
+++ b/src/lib/actions/opportunities.ts
@@ -2,7 +2,7 @@
 
 import { db } from "@/lib/db";
 import { opportunities, statusHistory } from "@/lib/db/schema";
-import { eq, desc, and } from "drizzle-orm";
+import { eq, desc, and, or, like } from "drizzle-orm";
 import { nanoid } from "nanoid";
 import { revalidatePath } from "next/cache";
 import type { Status } from "@/lib/constants";
@@ -25,7 +25,8 @@ async function recordStatusChange(
 
 export async function listOpportunities(
   statusFilter?: Status | "all",
-  showArchived = false
+  showArchived = false,
+  search?: string
 ) {
   const userId = await requireUserId();
   const conditions = [eq(opportunities.userId, userId)];
@@ -36,6 +37,18 @@ export async function listOpportunities(
 
   if (statusFilter && statusFilter !== "all") {
     conditions.push(eq(opportunities.status, statusFilter));
+  }
+
+  if (search) {
+    const pattern = `%${search}%`;
+    conditions.push(
+      or(
+        like(opportunities.company, pattern),
+        like(opportunities.role, pattern),
+        like(opportunities.jobId, pattern),
+        like(opportunities.location, pattern)
+      )!
+    );
   }
 
   return db


### PR DESCRIPTION
## Summary
- Activates the existing search input in the top bar to filter opportunities
- Searches across company, role, jobId, and location fields using case-insensitive `LIKE` queries
- Debounced input (300ms) with clear button
- Works in combination with status/archived filters via URL params

Closes #5

## Test plan
- [ ] Type in the search bar — results filter after 300ms
- [ ] Search works across company, role, job ID, and location
- [ ] Search combines with status filter (e.g., `?status=applied&search=react`)
- [ ] Clear (X) button resets search and removes URL param
- [ ] Search term persists on page reload via URL
- [ ] Empty/whitespace-only input does not trigger filtering

🤖 Generated with [Claude Code](https://claude.com/claude-code)