### PR TITLE
Replace status pill with standard Select dropdown

### DIFF
--- a/src/components/status-badge.tsx
+++ b/src/components/status-badge.tsx
@@ -2,11 +2,12 @@
 
 import { Badge } from "@/components/ui/badge";
 import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { STATUSES, STATUS_LABELS, STATUS_COLORS, type Status } from "@/lib/constants";
 import { updateOpportunityStatus } from "@/lib/actions/opportunities";
 
@@ -21,33 +22,36 @@ export function StatusBadge({
   opportunityId,
   interactive = true,
 }: StatusBadgeProps) {
-  const badge = (
-    <Badge
-      variant="outline"
-      className={`${STATUS_COLORS[status]} border-0 cursor-pointer text-[0.75rem] uppercase tracking-wide font-bold`}
-    >
-      {STATUS_LABELS[status]}
-    </Badge>
-  );
-
-  if (!interactive) return badge;
+  if (!interactive) {
+    return (
+      <Badge
+        variant="outline"
+        className={`${STATUS_COLORS[status]} border-0 text-[0.75rem] uppercase tracking-wide font-bold`}
+      >
+        {STATUS_LABELS[status]}
+      </Badge>
+    );
+  }
 
   return (
-    <DropdownMenu>
-      <DropdownMenuTrigger className="cursor-pointer">
-        {badge}
-      </DropdownMenuTrigger>
-      <DropdownMenuContent>
+    <Select
+      value={status}
+      onValueChange={(value) => updateOpportunityStatus(opportunityId, value as Status)}
+    >
+      <SelectTrigger className="w-40">
+        <SelectValue>
+          <span className={`inline-block w-2 h-2 rounded-full ${STATUS_COLORS[status]}`} />
+          {STATUS_LABELS[status]}
+        </SelectValue>
+      </SelectTrigger>
+      <SelectContent>
         {STATUSES.map((s) => (
-          <DropdownMenuItem
-            key={s}
-            onClick={() => updateOpportunityStatus(opportunityId, s)}
-          >
-            <span className={`inline-block w-2 h-2 rounded-full mr-2 ${STATUS_COLORS[s]}`} />
+          <SelectItem key={s} value={s}>
+            <span className={`inline-block w-2 h-2 rounded-full ${STATUS_COLORS[s]}`} />
             {STATUS_LABELS[s]}
-          </DropdownMenuItem>
+          </SelectItem>
         ))}
-      </DropdownMenuContent>
-    </DropdownMenu>
+      </SelectContent>
+    </Select>
   );
 }


### PR DESCRIPTION
## Summary

- Replaces the `DropdownMenu` + `Badge` pill status selector on the opportunity detail page with a proper `Select` dropdown component
- Adds a fixed width (`w-40`) so the selector is consistent regardless of which status is selected
- Keeps the non-interactive badge rendering unchanged for list/table contexts

Closes #21

## Test plan

- [ ] Navigate to an opportunity detail page and verify the status shows as a Select dropdown with chevron
- [ ] Click the dropdown and verify all statuses appear with colored dots
- [ ] Select a different status and verify it updates correctly
- [ ] Verify the dropdown width is consistent across all status values

🤖 Generated with [Claude Code](https://claude.com/claude-code)