### PR TITLE
Redesign opportunity detail page as GitHub-style timeline

### DIFF
--- a/scripts/migrate-notes-to-comments.ts
+++ b/scripts/migrate-notes-to-comments.ts
@@ -1,0 +1,111 @@
+/**
+ * Migration script: opportunities.notes -> opportunity_comments
+ *
+ * For every opportunity with a non-empty `notes` value, inserts one row into
+ * `opportunity_comments` with `body = notes` and `created_at = opportunity.created_at`,
+ * so the migrated note appears at the start of the timeline.
+ *
+ * Safe to re-run: skips opportunities that already have a migrated comment with
+ * the same body + createdAt.
+ *
+ * Prerequisites:
+ *   - `opportunity_comments` table exists (run `npm run db:push` first)
+ *   - The `notes` column is still present on `opportunities` (don't drop it until after)
+ *
+ * Usage:
+ *   # Local SQLite (default)
+ *   npx tsx scripts/migrate-notes-to-comments.ts
+ *
+ *   # Turso
+ *   TURSO_DATABASE_URL=<url> TURSO_AUTH_TOKEN=<token> npx tsx scripts/migrate-notes-to-comments.ts
+ *
+ *   # Dry run (report what would happen, no writes)
+ *   npx tsx scripts/migrate-notes-to-comments.ts --dry-run
+ */
+
+import { createClient } from "@libsql/client";
+import { drizzle } from "drizzle-orm/libsql";
+import { and, eq, sql } from "drizzle-orm";
+import { nanoid } from "nanoid";
+import { opportunities, opportunityComments } from "../src/lib/db/schema";
+
+const isDryRun = process.argv.includes("--dry-run");
+
+function createDb() {
+  const url = process.env.TURSO_DATABASE_URL;
+  const authToken = process.env.TURSO_AUTH_TOKEN;
+
+  if (url) {
+    return drizzle(createClient({ url, authToken }));
+  }
+
+  return drizzle(createClient({ url: "file:local.db" }));
+}
+
+async function main() {
+  const db = createDb();
+  const target = process.env.TURSO_DATABASE_URL ? "Turso" : "local.db";
+  console.log(`Migrating notes → opportunity_comments on ${target}${isDryRun ? " (dry run)" : ""}`);
+
+  const rows = await db
+    .select({
+      id: opportunities.id,
+      notes: sql<string | null>`notes`,
+      createdAt: opportunities.createdAt,
+    })
+    .from(opportunities);
+
+  let migrated = 0;
+  let skippedEmpty = 0;
+  let skippedExisting = 0;
+
+  for (const row of rows) {
+    const body = row.notes?.trim();
+    if (!body) {
+      skippedEmpty++;
+      continue;
+    }
+
+    const existing = await db
+      .select({ id: opportunityComments.id })
+      .from(opportunityComments)
+      .where(
+        and(
+          eq(opportunityComments.opportunityId, row.id),
+          eq(opportunityComments.body, body),
+          eq(opportunityComments.createdAt, row.createdAt)
+        )
+      )
+      .limit(1);
+
+    if (existing[0]) {
+      skippedExisting++;
+      continue;
+    }
+
+    if (!isDryRun) {
+      await db.insert(opportunityComments).values({
+        id: nanoid(),
+        opportunityId: row.id,
+        body,
+        createdAt: row.createdAt,
+        updatedAt: row.createdAt,
+      });
+    }
+    migrated++;
+  }
+
+  console.log(`Scanned: ${rows.length} opportunities`);
+  console.log(`Migrated: ${migrated}`);
+  console.log(`Skipped (empty notes): ${skippedEmpty}`);
+  console.log(`Skipped (already migrated): ${skippedExisting}`);
+
+  if (isDryRun) {
+    console.log("Dry run — no writes performed. Re-run without --dry-run to apply.");
+  }
+}
+
+main().catch((error) => {
+  console.error("Migration failed:", error);
+  process.exit(1);
+});

--- a/src/app/opportunities/[id]/page.tsx
+++ b/src/app/opportunities/[id]/page.tsx
@@ -3,14 +3,14 @@ import Link from "next/link";
 import { StatusBadge } from "@/components/status-badge";
 import { Markdown } from "@/components/markdown";
 import { OpportunityActions } from "@/components/opportunity-actions";
+import { OpportunityTimeline } from "@/components/opportunity-timeline";
 import {
   getOpportunity,
   getStatusHistory,
+  getComments,
 } from "@/lib/actions/opportunities";
 import type { Status, WorkMode, EmploymentType, ExperienceLevel } from "@/lib/constants";
 import {
-  STATUS_LABELS,
-  STATUS_DOT_COLORS,
   WORK_MODE_LABELS,
   EMPLOYMENT_TYPE_LABELS,
   EXPERIENCE_LEVEL_LABELS,
@@ -33,14 +33,16 @@ interface PageProps {
 
 export default async function OpportunityDetailPage({ params }: PageProps) {
   const { id } = await params;
-  const [opportunity, history] = await Promise.all([
-    getOpportunity(id),
-    getStatusHistory(id),
-  ]);
+  const opportunity = await getOpportunity(id);
 
   if (!opportunity) {
     notFound();
   }
+
+  const [history, comments] = await Promise.all([
+    getStatusHistory(id),
+    getComments(id),
+  ]);
 
   const locationDisplay = [
     opportunity.workMode
@@ -119,46 +121,11 @@ export default async function OpportunityDetailPage({ params }: PageProps) {
         </section>
       )}
 
-      {opportunity.notes && (
-        <section className="rounded-lg border bg-card p-5">
-          <h2 className="text-base font-semibold mb-3">Notes</h2>
-          <Markdown>{opportunity.notes}</Markdown>
-        </section>
-      )}
-
-      {history.length > 0 && (
-        <section className="rounded-lg border bg-card p-5">
-          <h2 className="text-base font-semibold mb-4">Status Timeline</h2>
-          <div className="space-y-3">
-            {history.map((entry) => (
-              <div key={entry.id} className="flex items-start gap-3 text-sm">
-                <span
-                  className={`mt-1.5 inline-block w-2 h-2 rounded-full shrink-0 ${
-                    STATUS_DOT_COLORS[entry.status as Status] ?? "bg-gray-400"
-                  }`}
-                />
-                <div className="flex-1">
-                  <div className="font-medium text-foreground">
-                    {STATUS_LABELS[entry.status as Status] ?? entry.status}
-                  </div>
-                  <div className="text-xs text-muted-foreground">
-                    {new Date(entry.changedAt).toLocaleDateString("en-US", {
-                      month: "short",
-                      day: "numeric",
-                      year: "numeric",
-                      hour: "numeric",
-                      minute: "2-digit",
-                    })}
-                  </div>
-                  {entry.note && (
-                    <div className="text-sm text-foreground mt-1">{entry.note}</div>
-                  )}
-                </div>
-              </div>
-            ))}
-          </div>
-        </section>
-      )}
+      <OpportunityTimeline
+        opportunityId={opportunity.id}
+        history={history}
+        comments={comments}
+      />
     </div>
   );
 

--- a/src/components/comment-composer.tsx
+++ b/src/components/comment-composer.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { addComment } from "@/lib/actions/opportunities";
+
+export function CommentComposer({ opportunityId }: { opportunityId: string }) {
+  const [body, setBody] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  const trimmed = body.trim();
+  const canSubmit = trimmed.length > 0 && !isPending;
+
+  function handleSubmit() {
+    if (!canSubmit) return;
+    setError(null);
+    startTransition(async () => {
+      try {
+        await addComment(opportunityId, trimmed);
+        setBody("");
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Failed to add comment");
+      }
+    });
+  }
+
+  return (
+    <div className="rounded-lg border bg-card">
+      <div className="px-4 py-3">
+        <Textarea
+          value={body}
+          onChange={(e) => setBody(e.target.value)}
+          rows={4}
+          placeholder="Leave a comment. Markdown supported."
+          disabled={isPending}
+          className="resize-y"
+        />
+        {error && (
+          <p className="mt-2 text-sm text-destructive">{error}</p>
+        )}
+      </div>
+      <footer className="flex items-center justify-end border-t px-4 py-2">
+        <Button type="button" onClick={handleSubmit} disabled={!canSubmit}>
+          {isPending ? "Commenting..." : "Comment"}
+        </Button>
+      </footer>
+    </div>
+  );
+}

--- a/src/components/layout/app-shell.tsx
+++ b/src/components/layout/app-shell.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { Suspense, useState } from "react";
 import { Sidebar } from "./sidebar";
 import { TopBar } from "./top-bar";
 
@@ -24,10 +24,12 @@ export function AppShell({ children, user, authEnabled }: AppShellProps) {
         onMobileClose={() => setMobileOpen(false)}
       />
       <div className="flex flex-1 flex-col min-w-0">
-        <TopBar
-          user={user}
-          onMobileMenuClick={() => setMobileOpen(true)}
-        />
+        <Suspense fallback={<div className="h-14 shrink-0 border-b" />}>
+          <TopBar
+            user={user}
+            onMobileMenuClick={() => setMobileOpen(true)}
+          />
+        </Suspense>
         <main className="flex-1 overflow-y-auto p-4 md:p-6">
           {children}
         </main>

--- a/src/components/opportunity-form.tsx
+++ b/src/components/opportunity-form.tsx
@@ -79,7 +79,6 @@ export function OpportunityForm({
     appliedAt: opportunity?.appliedAt ?? "",
     respondedAt: opportunity?.respondedAt ?? "",
     jobDescription: opportunity?.jobDescription ?? "",
-    notes: opportunity?.notes ?? "",
   });
 
   const [fieldErrors, setFieldErrors] = useState<Record<string, string | null>>({});
@@ -199,7 +198,6 @@ export function OpportunityForm({
       contactName: parsed.contactName ?? "",
       datePosted: parsed.datePosted ?? "",
       jobDescription: parsed.jobDescription ?? "",
-      notes: parsed.notes ?? "",
     }));
   }, []);
 
@@ -537,18 +535,6 @@ export function OpportunityForm({
           onChange={handleChange("jobDescription")}
           placeholder="Paste the full job posting here (description, responsibilities, requirements)..."
           className="resize-y"
-        />
-      </div>
-
-      <div className="space-y-2">
-        <Label htmlFor="notes">Notes</Label>
-        <Textarea
-          id="notes"
-          name="notes"
-          rows={4}
-          value={values.notes}
-          onChange={handleChange("notes")}
-          placeholder="Interview notes, contacts, etc."
         />
       </div>
 

--- a/src/components/opportunity-timeline.tsx
+++ b/src/components/opportunity-timeline.tsx
@@ -23,6 +23,13 @@ type TimelineEvent =
       body: string;
     };
 
+// On exact timestamp ties, structural events (status changes) render before
+// reactive events (comments) — matches GitHub's timeline behavior.
+const EVENT_PRIORITY: Record<TimelineEvent["kind"], number> = {
+  status: 0,
+  comment: 1,
+};
+
 function buildEvents(
   history: StatusHistory[],
   comments: OpportunityComment[]
@@ -42,9 +49,11 @@ function buildEvents(
     body: entry.body,
   }));
 
-  return [...statusEvents, ...commentEvents].sort((a, b) =>
-    a.timestamp.localeCompare(b.timestamp)
-  );
+  return [...statusEvents, ...commentEvents].sort((a, b) => {
+    const byTime = a.timestamp.localeCompare(b.timestamp);
+    if (byTime !== 0) return byTime;
+    return EVENT_PRIORITY[a.kind] - EVENT_PRIORITY[b.kind];
+  });
 }
 
 function formatAbsolute(timestamp: string) {
@@ -89,7 +98,8 @@ function StatusEvent({
   return (
     <li className="relative pl-8">
       <span
-        className={`absolute left-[13px] top-2 inline-block w-2 h-2 rounded-full ring-4 ring-background ${dotColor}`}
+        aria-hidden
+        className={`absolute left-4 top-2 -translate-x-1/2 inline-block w-2 h-2 rounded-full ring-4 ring-background ${dotColor}`}
       />
       <div className="flex flex-wrap items-baseline gap-x-2 text-sm">
         <span className="text-muted-foreground">Marked as</span>
@@ -118,7 +128,10 @@ function CommentEvent({
 }) {
   return (
     <li className="relative pl-8">
-      <span className="absolute left-[9px] top-2 flex h-5 w-5 items-center justify-center rounded-full bg-muted text-muted-foreground ring-4 ring-background">
+      <span
+        aria-hidden
+        className="absolute left-4 top-2 -translate-x-1/2 flex h-5 w-5 items-center justify-center rounded-full bg-muted text-muted-foreground ring-4 ring-background"
+      >
         <MessageSquare className="h-3 w-3" />
       </span>
       <div className="rounded-lg border bg-card">
@@ -151,35 +164,40 @@ export function OpportunityTimeline({
   const events = buildEvents(history, comments);
 
   return (
-    <div className="relative">
+    <section aria-label="Activity" className="relative">
       <span
         aria-hidden
-        className="absolute left-[17px] top-2 bottom-2 w-px bg-border"
+        className="absolute left-4 top-2 bottom-2 -translate-x-1/2 w-px bg-border"
       />
-      <ul className="space-y-5">
-        {events.map((event) =>
-          event.kind === "status" ? (
-            <StatusEvent
-              key={`status-${event.id}`}
-              status={event.status}
-              timestamp={event.timestamp}
-              note={event.note}
-            />
-          ) : (
-            <CommentEvent
-              key={`comment-${event.id}`}
-              body={event.body}
-              timestamp={event.timestamp}
-            />
-          )
-        )}
-        <li className="relative pl-8">
-          <span className="absolute left-[9px] top-2 flex h-5 w-5 items-center justify-center rounded-full bg-muted text-muted-foreground ring-4 ring-background">
-            <MessageSquare className="h-3 w-3" />
-          </span>
-          <CommentComposer opportunityId={opportunityId} />
-        </li>
-      </ul>
-    </div>
+      {events.length > 0 && (
+        <ul className="space-y-5">
+          {events.map((event) =>
+            event.kind === "status" ? (
+              <StatusEvent
+                key={`status-${event.id}`}
+                status={event.status}
+                timestamp={event.timestamp}
+                note={event.note}
+              />
+            ) : (
+              <CommentEvent
+                key={`comment-${event.id}`}
+                body={event.body}
+                timestamp={event.timestamp}
+              />
+            )
+          )}
+        </ul>
+      )}
+      <div className={`relative pl-8 ${events.length > 0 ? "mt-5" : ""}`}>
+        <span
+          aria-hidden
+          className="absolute left-4 top-2 -translate-x-1/2 flex h-5 w-5 items-center justify-center rounded-full bg-muted text-muted-foreground ring-4 ring-background"
+        >
+          <MessageSquare className="h-3 w-3" />
+        </span>
+        <CommentComposer opportunityId={opportunityId} />
+      </div>
+    </section>
   );
 }

--- a/src/components/opportunity-timeline.tsx
+++ b/src/components/opportunity-timeline.tsx
@@ -1,0 +1,185 @@
+import { MessageSquare } from "lucide-react";
+import { Markdown } from "@/components/markdown";
+import { CommentComposer } from "@/components/comment-composer";
+import {
+  STATUS_LABELS,
+  STATUS_DOT_COLORS,
+  type Status,
+} from "@/lib/constants";
+import type { StatusHistory, OpportunityComment } from "@/lib/db/schema";
+
+type TimelineEvent =
+  | {
+      kind: "status";
+      id: string;
+      timestamp: string;
+      status: string;
+      note: string | null;
+    }
+  | {
+      kind: "comment";
+      id: string;
+      timestamp: string;
+      body: string;
+    };
+
+function buildEvents(
+  history: StatusHistory[],
+  comments: OpportunityComment[]
+): TimelineEvent[] {
+  const statusEvents: TimelineEvent[] = history.map((entry) => ({
+    kind: "status",
+    id: entry.id,
+    timestamp: entry.changedAt,
+    status: entry.status,
+    note: entry.note,
+  }));
+
+  const commentEvents: TimelineEvent[] = comments.map((entry) => ({
+    kind: "comment",
+    id: entry.id,
+    timestamp: entry.createdAt,
+    body: entry.body,
+  }));
+
+  return [...statusEvents, ...commentEvents].sort((a, b) =>
+    a.timestamp.localeCompare(b.timestamp)
+  );
+}
+
+function formatAbsolute(timestamp: string) {
+  return new Date(timestamp).toLocaleString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
+function formatRelative(timestamp: string) {
+  const then = new Date(timestamp).getTime();
+  const now = Date.now();
+  const diffMs = now - then;
+  const minutes = Math.round(diffMs / 60_000);
+  if (minutes < 1) return "just now";
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.round(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.round(hours / 24);
+  if (days < 30) return `${days}d ago`;
+  const months = Math.round(days / 30);
+  if (months < 12) return `${months}mo ago`;
+  const years = Math.round(months / 12);
+  return `${years}y ago`;
+}
+
+function StatusEvent({
+  status,
+  timestamp,
+  note,
+}: {
+  status: string;
+  timestamp: string;
+  note: string | null;
+}) {
+  const label = STATUS_LABELS[status as Status] ?? status;
+  const dotColor = STATUS_DOT_COLORS[status as Status] ?? "bg-gray-400";
+
+  return (
+    <li className="relative pl-8">
+      <span
+        className={`absolute left-[13px] top-2 inline-block w-2 h-2 rounded-full ring-4 ring-background ${dotColor}`}
+      />
+      <div className="flex flex-wrap items-baseline gap-x-2 text-sm">
+        <span className="text-muted-foreground">Marked as</span>
+        <span className="font-medium text-foreground">{label}</span>
+        <time
+          dateTime={timestamp}
+          title={formatAbsolute(timestamp)}
+          className="text-xs text-muted-foreground"
+        >
+          {formatRelative(timestamp)}
+        </time>
+      </div>
+      {note && (
+        <p className="mt-1 text-sm text-foreground">{note}</p>
+      )}
+    </li>
+  );
+}
+
+function CommentEvent({
+  body,
+  timestamp,
+}: {
+  body: string;
+  timestamp: string;
+}) {
+  return (
+    <li className="relative pl-8">
+      <span className="absolute left-[9px] top-2 flex h-5 w-5 items-center justify-center rounded-full bg-muted text-muted-foreground ring-4 ring-background">
+        <MessageSquare className="h-3 w-3" />
+      </span>
+      <div className="rounded-lg border bg-card">
+        <header className="flex items-center justify-between border-b px-4 py-2">
+          <time
+            dateTime={timestamp}
+            title={formatAbsolute(timestamp)}
+            className="text-xs text-muted-foreground"
+          >
+            commented {formatRelative(timestamp)}
+          </time>
+        </header>
+        <div className="px-4 py-3">
+          <Markdown>{body}</Markdown>
+        </div>
+      </div>
+    </li>
+  );
+}
+
+export function OpportunityTimeline({
+  opportunityId,
+  history,
+  comments,
+}: {
+  opportunityId: string;
+  history: StatusHistory[];
+  comments: OpportunityComment[];
+}) {
+  const events = buildEvents(history, comments);
+
+  return (
+    <div className="relative">
+      <span
+        aria-hidden
+        className="absolute left-[17px] top-2 bottom-2 w-px bg-border"
+      />
+      <ul className="space-y-5">
+        {events.map((event) =>
+          event.kind === "status" ? (
+            <StatusEvent
+              key={`status-${event.id}`}
+              status={event.status}
+              timestamp={event.timestamp}
+              note={event.note}
+            />
+          ) : (
+            <CommentEvent
+              key={`comment-${event.id}`}
+              body={event.body}
+              timestamp={event.timestamp}
+            />
+          )
+        )}
+        <li className="relative pl-8">
+          <span className="absolute left-[9px] top-2 flex h-5 w-5 items-center justify-center rounded-full bg-muted text-muted-foreground ring-4 ring-background">
+            <MessageSquare className="h-3 w-3" />
+          </span>
+          <CommentComposer opportunityId={opportunityId} />
+        </li>
+      </ul>
+    </div>
+  );
+}

--- a/src/lib/actions/opportunities.ts
+++ b/src/lib/actions/opportunities.ts
@@ -1,13 +1,25 @@
 "use server";
 
 import { db } from "@/lib/db";
-import { opportunities, statusHistory } from "@/lib/db/schema";
-import { eq, desc, and, sql } from "drizzle-orm";
+import { opportunities, statusHistory, opportunityComments } from "@/lib/db/schema";
+import { eq, asc, desc, and, sql } from "drizzle-orm";
 import { nanoid } from "nanoid";
 import { revalidatePath } from "next/cache";
 import type { Status } from "@/lib/constants";
 import { requireUserId } from "@/lib/auth-optional";
 import { parseFormData, type OpportunityFormState } from "@/lib/validations/opportunity";
+
+async function assertOpportunityOwnership(opportunityId: string, userId: string) {
+  const rows = await db
+    .select({ id: opportunities.id })
+    .from(opportunities)
+    .where(and(eq(opportunities.id, opportunityId), eq(opportunities.userId, userId)))
+    .limit(1);
+
+  if (!rows[0]) {
+    throw new Error("Opportunity not found");
+  }
+}
 
 async function recordStatusChange(
   opportunityId: string,
@@ -105,7 +117,39 @@ export async function getStatusHistory(opportunityId: string) {
     .select()
     .from(statusHistory)
     .where(eq(statusHistory.opportunityId, opportunityId))
-    .orderBy(desc(statusHistory.changedAt));
+    .orderBy(asc(statusHistory.changedAt));
+}
+
+export async function getComments(opportunityId: string) {
+  const userId = await requireUserId();
+  await assertOpportunityOwnership(opportunityId, userId);
+
+  return db
+    .select()
+    .from(opportunityComments)
+    .where(eq(opportunityComments.opportunityId, opportunityId))
+    .orderBy(asc(opportunityComments.createdAt));
+}
+
+export async function addComment(opportunityId: string, body: string) {
+  const userId = await requireUserId();
+  await assertOpportunityOwnership(opportunityId, userId);
+
+  const trimmed = body.trim();
+  if (!trimmed) {
+    throw new Error("Comment cannot be empty");
+  }
+
+  const now = new Date().toISOString();
+  await db.insert(opportunityComments).values({
+    id: nanoid(),
+    opportunityId,
+    body: trimmed,
+    createdAt: now,
+    updatedAt: now,
+  });
+
+  revalidatePath(`/opportunities/${opportunityId}`);
 }
 
 export async function createOpportunity(
@@ -144,7 +188,6 @@ export async function createOpportunity(
     datePosted: data.datePosted,
     contactName: data.contactName,
     jobDescription: data.jobDescription,
-    notes: data.notes,
     appliedAt: data.appliedAt,
     createdAt: now,
     updatedAt: now,
@@ -198,7 +241,6 @@ export async function updateOpportunity(
       datePosted: data.datePosted,
       contactName: data.contactName,
       jobDescription: data.jobDescription,
-      notes: data.notes,
       appliedAt: data.appliedAt,
       respondedAt: data.respondedAt,
       updatedAt: new Date().toISOString(),
@@ -217,6 +259,16 @@ export async function updateOpportunity(
 export async function updateOpportunityStatus(id: string, status: Status) {
   const userId = await requireUserId();
 
+  const existing = await db
+    .select({ status: opportunities.status })
+    .from(opportunities)
+    .where(and(eq(opportunities.id, id), eq(opportunities.userId, userId)))
+    .limit(1);
+
+  if (!existing[0] || existing[0].status === status) {
+    return;
+  }
+
   await db
     .update(opportunities)
     .set({
@@ -228,6 +280,7 @@ export async function updateOpportunityStatus(id: string, status: Status) {
   await recordStatusChange(id, status);
 
   revalidatePath("/");
+  revalidatePath(`/opportunities/${id}`);
 }
 
 export async function archiveOpportunity(id: string) {

--- a/src/lib/actions/opportunities.ts
+++ b/src/lib/actions/opportunities.ts
@@ -265,7 +265,10 @@ export async function updateOpportunityStatus(id: string, status: Status) {
     .where(and(eq(opportunities.id, id), eq(opportunities.userId, userId)))
     .limit(1);
 
-  if (!existing[0] || existing[0].status === status) {
+  if (!existing[0]) {
+    throw new Error("Opportunity not found");
+  }
+  if (existing[0].status === status) {
     return;
   }
 

--- a/src/lib/actions/parse-job-posting.ts
+++ b/src/lib/actions/parse-job-posting.ts
@@ -36,7 +36,6 @@ Rules:
 - Use salaryMin and salaryMax as yearly whole-number amounts in USD when the posting gives a clear annual range.
 - Use datePosted in YYYY-MM-DD format only when the exact date is available.
 - Put the main job posting text in jobDescription when available.
-- Put useful extra context that does not fit elsewhere into notes.
 - Do not invent details.
 `;
 
@@ -268,7 +267,6 @@ function normalizeParsedJobPosting(
     jobId: normalizeWhitespace(data.jobId),
     contactName: normalizeWhitespace(data.contactName),
     jobDescription: normalizeWhitespace(data.jobDescription),
-    notes: normalizeWhitespace(data.notes),
   };
 
   if (input.sourceType === "url") {

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -78,7 +78,6 @@ export const opportunities = sqliteTable(
     datePosted: text("date_posted"),
     contactName: text("contact_name"),
     jobDescription: text("job_description"),
-    notes: text("notes"),
     appliedAt: text("applied_at"),
     respondedAt: text("responded_at"),
     createdAt: text("created_at")
@@ -117,6 +116,29 @@ export const statusHistory = sqliteTable(
   ]
 );
 
+export const opportunityComments = sqliteTable(
+  "opportunity_comments",
+  {
+    id: text("id").primaryKey(),
+    opportunityId: text("opportunity_id")
+      .notNull()
+      .references(() => opportunities.id, { onDelete: "cascade" }),
+    body: text("body").notNull(),
+    createdAt: text("created_at")
+      .notNull()
+      .default(sql`(datetime('now'))`),
+    updatedAt: text("updated_at")
+      .notNull()
+      .default(sql`(datetime('now'))`),
+  },
+  (table) => [
+    index("idx_opportunity_comments_opp_created").on(
+      table.opportunityId,
+      table.createdAt
+    ),
+  ]
+);
+
 export type User = typeof users.$inferSelect;
 export type NewUser = typeof users.$inferInsert;
 export type Account = typeof accounts.$inferSelect;
@@ -125,3 +147,5 @@ export type Opportunity = typeof opportunities.$inferSelect;
 export type NewOpportunity = typeof opportunities.$inferInsert;
 export type StatusHistory = typeof statusHistory.$inferSelect;
 export type NewStatusHistory = typeof statusHistory.$inferInsert;
+export type OpportunityComment = typeof opportunityComments.$inferSelect;
+export type NewOpportunityComment = typeof opportunityComments.$inferInsert;

--- a/src/lib/validations/opportunity.ts
+++ b/src/lib/validations/opportunity.ts
@@ -72,10 +72,6 @@ export const opportunitySchema = z.object({
     .string()
     .optional()
     .transform((v) => v || null),
-  notes: z
-    .string()
-    .optional()
-    .transform((v) => v || null),
   appliedAt: z
     .string()
     .optional()
@@ -177,7 +173,6 @@ export function parseFormData(formData: FormData) {
     datePosted: getOptionalFormValue(formData, "datePosted"),
     contactName: getOptionalFormValue(formData, "contactName"),
     jobDescription: getOptionalFormValue(formData, "jobDescription"),
-    notes: getOptionalFormValue(formData, "notes"),
     appliedAt: getOptionalFormValue(formData, "appliedAt"),
     respondedAt: getOptionalFormValue(formData, "respondedAt"),
   });

--- a/src/lib/validations/parse-job-posting.ts
+++ b/src/lib/validations/parse-job-posting.ts
@@ -57,7 +57,6 @@ export const parsedJobPostingSchema = z.object({
   datePosted: optionalIsoDateString(),
   contactName: optionalTrimmedString(),
   jobDescription: optionalTrimmedString(),
-  notes: optionalTrimmedString(),
 });
 
 export type ParsedJobPosting = z.infer<typeof parsedJobPostingSchema>;


### PR DESCRIPTION
Closes #27, closes #23.

## Summary

- Merge Job Description / Notes / Status Timeline into a single linear feed modeled on GitHub issues
- New `opportunity_comments` table replaces the single-blob `opportunities.notes` field
- Comment composer at the bottom of the timeline accepts markdown and appends a new entry
- Selecting the same status from the dropdown is now a no-op (fixes #23)

Existing `notes` values have been migrated into seed comments via `scripts/migrate-notes-to-comments.ts` (already run locally; needs to be run against Turso on deploy).

## Changes

- **Schema**: add `opportunity_comments` (`id`, `opportunity_id`, `body`, `created_at`, `updated_at` + composite index); drop `opportunities.notes`.
- **Server actions**: `getComments`, `addComment` (both verify owner via new `assertOpportunityOwnership` helper). `getStatusHistory` now returns ascending for timeline ordering.
- **UI**: `OpportunityTimeline` (server component, merges and sorts) with `StatusEvent` / `CommentEvent` renderers and a left rail. `CommentComposer` (client) wires up `addComment`.
- **Form**: Notes textarea removed; AI parser `notes` field removed.
- **Bug fix**: `updateOpportunityStatus` short-circuits when the status is unchanged, and now revalidates `/opportunities/[id]` so the detail page reflects the new badge.

## Deployment steps (for merge)

1. `TURSO_DATABASE_URL=<url> TURSO_AUTH_TOKEN=<token> npx tsx scripts/migrate-notes-to-comments.ts --dry-run` — confirm migration count matches expectations.
2. Run the same command without `--dry-run` to migrate production notes into comments.
3. `TURSO_DATABASE_URL=<url> TURSO_AUTH_TOKEN=<token> npm run db:push -- --force` — drops the `notes` column after the data is safely copied.

## Follow-ups (already filed)

- #28 — edit/delete comments with a kebab menu
- #29 — rich markdown editor (toolbar, preview, list continuation)

## Test plan

- [x] Create a new opportunity; timeline shows the initial status event
- [x] Change the status via the badge; new event appears in the timeline
- [x] Re-select the current status; no new event (fixes #23)
- [x] Add a comment via the composer; it appears at the bottom of the timeline
- [x] Existing opportunities that had notes now show a seed comment at the start of the timeline (verified against 4 migrated rows locally)
- [x] Edit form no longer has a Notes field
- [ ] Verify Turso migration against a backup before running against prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)