### PR TITLE
Rework opportunity detail page to GitHub-style layout

### DIFF
--- a/src/app/opportunities/[id]/page.tsx
+++ b/src/app/opportunities/[id]/page.tsx
@@ -1,5 +1,6 @@
 import { notFound } from "next/navigation";
 import Link from "next/link";
+import { ExternalLink } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { StatusBadge } from "@/components/status-badge";
 import { Markdown } from "@/components/markdown";
@@ -54,6 +55,18 @@ export default async function OpportunityDetailPage({ params }: PageProps) {
     .filter(Boolean)
     .join(" · ");
 
+  const viewPostingLink = opportunity.url ? (
+    <a
+      href={opportunity.url}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="flex items-center gap-2 text-sm font-medium text-primary hover:underline"
+    >
+      <ExternalLink className="size-4" />
+      View job posting
+    </a>
+  ) : null;
+
   const metadataCard = (
     <div>
       <dl className="space-y-4">
@@ -94,18 +107,6 @@ export default async function OpportunityDetailPage({ params }: PageProps) {
         )}
         {opportunity.respondedAt && (
           <Field label="Responded">{opportunity.respondedAt}</Field>
-        )}
-        {opportunity.url && (
-          <Field label="Posting">
-            <a
-              href={opportunity.url}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-primary underline"
-            >
-              View posting
-            </a>
-          </Field>
         )}
       </dl>
     </div>
@@ -168,9 +169,12 @@ export default async function OpportunityDetailPage({ params }: PageProps) {
         </div>
       </div>
 
+      {viewPostingLink && <div className="lg:hidden">{viewPostingLink}</div>}
+
       <div className="lg:grid lg:grid-cols-3 lg:gap-8">
         <div className="lg:col-span-2">{mainContent}</div>
-        <aside className="hidden lg:block lg:col-span-1">
+        <aside className="hidden lg:block lg:col-span-1 space-y-4">
+          {viewPostingLink}
           {metadataCard}
           {sidebarActions}
         </aside>

--- a/src/app/opportunities/[id]/page.tsx
+++ b/src/app/opportunities/[id]/page.tsx
@@ -173,14 +173,14 @@ export default async function OpportunityDetailPage({ params }: PageProps) {
 
       <div className="lg:grid lg:grid-cols-3 lg:gap-8">
         <div className="lg:col-span-2">{mainContent}</div>
-        <aside className="hidden lg:block lg:col-span-1 space-y-4">
+        <aside className="hidden lg:block lg:col-span-1 space-y-6">
           {viewPostingLink}
           {metadataCard}
           {sidebarActions}
         </aside>
       </div>
 
-      <div className="lg:hidden mt-6 border-t pt-6">{metadataCard}</div>
+      <div className="lg:hidden border-t pt-6">{metadataCard}</div>
       <div className="lg:hidden">{sidebarActions}</div>
     </div>
   );

--- a/src/app/opportunities/[id]/page.tsx
+++ b/src/app/opportunities/[id]/page.tsx
@@ -1,8 +1,9 @@
 import { notFound } from "next/navigation";
 import Link from "next/link";
+import { Button } from "@/components/ui/button";
 import { StatusBadge } from "@/components/status-badge";
 import { Markdown } from "@/components/markdown";
-import { OpportunityActions } from "@/components/opportunity-actions";
+import { OpportunitySidebarActions } from "@/components/opportunity-actions";
 import { OpportunityTimeline } from "@/components/opportunity-timeline";
 import {
   getOpportunity,
@@ -53,63 +54,68 @@ export default async function OpportunityDetailPage({ params }: PageProps) {
     .filter(Boolean)
     .join(" · ");
 
-  const sidebar = (
-    <div className="space-y-6">
-      <div className="rounded-lg border bg-card p-5">
-        <dl className="space-y-4">
-          {locationDisplay && <Field label="Location">{locationDisplay}</Field>}
-          {opportunity.department && (
-            <Field label="Department">{opportunity.department}</Field>
-          )}
-          {opportunity.employmentType && (
-            <Field label="Employment Type">
-              {EMPLOYMENT_TYPE_LABELS[opportunity.employmentType as EmploymentType] ??
-                opportunity.employmentType}
-            </Field>
-          )}
-          {opportunity.experienceLevel && (
-            <Field label="Experience Level">
-              {EXPERIENCE_LEVEL_LABELS[opportunity.experienceLevel as ExperienceLevel] ??
-                opportunity.experienceLevel}
-            </Field>
-          )}
-          {opportunity.jobId && <Field label="Job ID">{opportunity.jobId}</Field>}
-          {(opportunity.salaryMin || opportunity.salaryMax) && (
-            <Field label="Salary">
-              {opportunity.salaryMin &&
-                `$${opportunity.salaryMin.toLocaleString()}`}
-              {opportunity.salaryMin && opportunity.salaryMax && " – "}
-              {opportunity.salaryMax &&
-                `$${opportunity.salaryMax.toLocaleString()}`}
-            </Field>
-          )}
-          {opportunity.contactName && (
-            <Field label="Contact">{opportunity.contactName}</Field>
-          )}
-          {opportunity.datePosted && (
-            <Field label="Date Posted">{opportunity.datePosted}</Field>
-          )}
-          {opportunity.appliedAt && (
-            <Field label="Applied">{opportunity.appliedAt}</Field>
-          )}
-          {opportunity.respondedAt && (
-            <Field label="Responded">{opportunity.respondedAt}</Field>
-          )}
-          {opportunity.url && (
-            <Field label="Posting">
-              <a
-                href={opportunity.url}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-primary underline"
-              >
-                View posting
-              </a>
-            </Field>
-          )}
-        </dl>
-      </div>
+  const metadataCard = (
+    <div>
+      <dl className="space-y-4">
+        {locationDisplay && <Field label="Location">{locationDisplay}</Field>}
+        {opportunity.department && (
+          <Field label="Department">{opportunity.department}</Field>
+        )}
+        {opportunity.employmentType && (
+          <Field label="Employment Type">
+            {EMPLOYMENT_TYPE_LABELS[opportunity.employmentType as EmploymentType] ??
+              opportunity.employmentType}
+          </Field>
+        )}
+        {opportunity.experienceLevel && (
+          <Field label="Experience Level">
+            {EXPERIENCE_LEVEL_LABELS[opportunity.experienceLevel as ExperienceLevel] ??
+              opportunity.experienceLevel}
+          </Field>
+        )}
+        {opportunity.jobId && <Field label="Job ID">{opportunity.jobId}</Field>}
+        {(opportunity.salaryMin || opportunity.salaryMax) && (
+          <Field label="Salary">
+            {opportunity.salaryMin &&
+              `$${opportunity.salaryMin.toLocaleString()}`}
+            {opportunity.salaryMin && opportunity.salaryMax && " – "}
+            {opportunity.salaryMax &&
+              `$${opportunity.salaryMax.toLocaleString()}`}
+          </Field>
+        )}
+        {opportunity.contactName && (
+          <Field label="Contact">{opportunity.contactName}</Field>
+        )}
+        {opportunity.datePosted && (
+          <Field label="Date Posted">{opportunity.datePosted}</Field>
+        )}
+        {opportunity.appliedAt && (
+          <Field label="Applied">{opportunity.appliedAt}</Field>
+        )}
+        {opportunity.respondedAt && (
+          <Field label="Responded">{opportunity.respondedAt}</Field>
+        )}
+        {opportunity.url && (
+          <Field label="Posting">
+            <a
+              href={opportunity.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-primary underline"
+            >
+              View posting
+            </a>
+          </Field>
+        )}
+      </dl>
     </div>
+  );
+
+  const sidebarActions = (
+    <OpportunitySidebarActions
+      id={opportunity.id}
+      archived={opportunity.archived === 1}
+    />
   );
 
   const mainContent = (
@@ -141,26 +147,37 @@ export default async function OpportunityDetailPage({ params }: PageProps) {
         </span>
       </nav>
 
-      <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
-        <div className="space-y-1 min-w-0">
+      <div className="flex flex-col-reverse gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <div className="space-y-2 min-w-0">
           <h1 className="text-3xl font-bold tracking-tight">{opportunity.company}</h1>
           <p className="text-lg text-muted-foreground">{opportunity.role}</p>
+          <div className="pt-1">
+            <StatusBadge
+              status={opportunity.status as Status}
+              opportunityId={opportunity.id}
+            />
+          </div>
         </div>
         <div className="flex items-center gap-2 shrink-0">
-          <StatusBadge
-            status={opportunity.status as Status}
-            opportunityId={opportunity.id}
-          />
-          <OpportunityActions id={opportunity.id} />
+          <Link href={`/opportunities/${opportunity.id}/edit`}>
+            <Button>Edit</Button>
+          </Link>
+          <Link href="/opportunities/new">
+            <Button variant="outline">New opportunity</Button>
+          </Link>
         </div>
       </div>
-
-      <div className="lg:hidden">{sidebar}</div>
 
       <div className="lg:grid lg:grid-cols-3 lg:gap-8">
         <div className="lg:col-span-2">{mainContent}</div>
-        <aside className="hidden lg:block lg:col-span-1">{sidebar}</aside>
+        <aside className="hidden lg:block lg:col-span-1">
+          {metadataCard}
+          {sidebarActions}
+        </aside>
       </div>
+
+      <div className="lg:hidden mt-6 border-t pt-6">{metadataCard}</div>
+      <div className="lg:hidden">{sidebarActions}</div>
     </div>
   );
 }

--- a/src/components/opportunity-actions.tsx
+++ b/src/components/opportunity-actions.tsx
@@ -35,7 +35,7 @@ export function OpportunitySidebarActions({
   };
 
   return (
-    <div className="mt-6 border-t pt-6">
+    <div className="border-t pt-6">
       <div className="-mx-2 flex flex-col gap-1">
         <button
           type="button"

--- a/src/components/opportunity-actions.tsx
+++ b/src/components/opportunity-actions.tsx
@@ -1,26 +1,30 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import Link from "next/link";
-import { MoreHorizontal } from "lucide-react";
-import { Button } from "@/components/ui/button";
-import {
-  DropdownMenu,
-  DropdownMenuTrigger,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuSeparator,
-} from "@/components/ui/dropdown-menu";
+import { Archive, ArchiveRestore, Trash2 } from "lucide-react";
 import {
   archiveOpportunity,
+  unarchiveOpportunity,
   deleteOpportunity,
 } from "@/lib/actions/opportunities";
 
-export function OpportunityActions({ id }: { id: string }) {
+interface OpportunitySidebarActionsProps {
+  id: string;
+  archived: boolean;
+}
+
+export function OpportunitySidebarActions({
+  id,
+  archived,
+}: OpportunitySidebarActionsProps) {
   const router = useRouter();
 
-  const handleArchive = async () => {
-    await archiveOpportunity(id);
+  const handleArchiveToggle = async () => {
+    if (archived) {
+      await unarchiveOpportunity(id);
+    } else {
+      await archiveOpportunity(id);
+    }
     router.push("/");
   };
 
@@ -31,24 +35,29 @@ export function OpportunityActions({ id }: { id: string }) {
   };
 
   return (
-    <div className="flex items-center gap-2">
-      <Link href={`/opportunities/${id}/edit`}>
-        <Button>Edit</Button>
-      </Link>
-      <DropdownMenu>
-        <DropdownMenuTrigger
-          render={<Button variant="outline" size="icon" aria-label="More actions" />}
+    <div className="mt-6 border-t pt-6">
+      <div className="-mx-2 flex flex-col gap-1">
+        <button
+          type="button"
+          onClick={handleArchiveToggle}
+          className="flex items-center gap-2 rounded-md px-2 py-1.5 text-sm text-muted-foreground hover:bg-muted hover:text-foreground transition-colors w-full"
         >
-          <MoreHorizontal className="size-4" />
-        </DropdownMenuTrigger>
-        <DropdownMenuContent align="end">
-          <DropdownMenuItem onClick={handleArchive}>Archive</DropdownMenuItem>
-          <DropdownMenuSeparator />
-          <DropdownMenuItem variant="destructive" onClick={handleDelete}>
-            Delete
-          </DropdownMenuItem>
-        </DropdownMenuContent>
-      </DropdownMenu>
+          {archived ? (
+            <ArchiveRestore className="size-4" />
+          ) : (
+            <Archive className="size-4" />
+          )}
+          {archived ? "Unarchive opportunity" : "Archive opportunity"}
+        </button>
+        <button
+          type="button"
+          onClick={handleDelete}
+          className="flex items-center gap-2 rounded-md px-2 py-1.5 text-sm text-destructive hover:bg-destructive/10 transition-colors w-full"
+        >
+          <Trash2 className="size-4" />
+          Delete opportunity
+        </button>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
Closes #31.

## Summary

- **Top-right actions:** Edit + "New opportunity" buttons replace the 3-dot overflow menu. On narrow viewports they stack above the title (flex-col-reverse), matching GitHub's mobile issue layout.
- **Status:** Interactive status dropdown moves from the upper right to directly under the company/role title, so the top-right can focus on primary actions.
- **Archive / Delete:** No longer hidden behind an overflow menu. Rendered as link-styled icon buttons (Archive, Trash2) under the metadata, with subtle hover backgrounds. Archive toggles to **Unarchive** when `opportunity.archived === 1`, wiring up the existing `unarchiveOpportunity` server action that wasn't reachable from the detail page before.
- **View job posting:** Promoted out of the metadata list to a prominent primary-colored link with an `ExternalLink` icon at the top of the sidebar on desktop, and rendered right under the header on mobile so it isn't buried at the bottom.
- **Metadata card chrome removed:** No more bordered card wrapper — metadata is plain labeled fields with GitHub-style `border-t` section dividers between sidebar sections.
- **Mobile layout:** Main content first, then metadata and actions at the bottom of the page, each preceded by a section divider.

## Test plan

- [ ] Open an opportunity detail page on desktop (≥ lg). Verify:
  - [ ] Top-right shows Edit + New opportunity; no 3-dot menu
  - [ ] Status dropdown sits under the role; changing it still updates the opportunity
  - [ ] Sidebar shows: View job posting → metadata fields → Archive/Delete links
  - [ ] Archive link toggles to "Unarchive opportunity" after archiving and back again
  - [ ] Delete still shows the native confirm() and removes the opportunity
- [ ] Narrow the window below `lg`. Verify:
  - [ ] Edit + New opportunity stack above the title
  - [ ] View job posting renders under the header (not at the bottom)
  - [ ] Metadata and Archive/Delete move to the bottom of the page, each with a divider above
- [ ] Opportunity with no `url` — "View job posting" link simply doesn't render
- [ ] Opportunity in archived state — link reads "Unarchive opportunity" with the ArchiveRestore icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)