### PR TITLE
Move opportunity list to /opportunities route

### DIFF
--- a/src/app/opportunities/[id]/edit/page.tsx
+++ b/src/app/opportunities/[id]/edit/page.tsx
@@ -18,8 +18,8 @@ export default async function EditOpportunityPage({ params }: PageProps) {
   return (
     <div className="space-y-6">
       <nav className="text-sm text-muted-foreground">
-        <Link href="/" className="hover:text-foreground">
-          Applications
+        <Link href="/opportunities" className="hover:text-foreground">
+          Opportunities
         </Link>
         <span className="mx-1.5">&rsaquo;</span>
         <Link

--- a/src/app/opportunities/[id]/page.tsx
+++ b/src/app/opportunities/[id]/page.tsx
@@ -139,8 +139,8 @@ export default async function OpportunityDetailPage({ params }: PageProps) {
   return (
     <div className="space-y-6 max-w-5xl">
       <nav className="text-sm text-muted-foreground">
-        <Link href="/" className="hover:text-foreground">
-          Applications
+        <Link href="/opportunities" className="hover:text-foreground">
+          Opportunities
         </Link>
         <span className="mx-1.5">&rsaquo;</span>
         <span className="text-foreground font-medium">

--- a/src/app/opportunities/new/page.tsx
+++ b/src/app/opportunities/new/page.tsx
@@ -7,8 +7,8 @@ export default function NewOpportunityPage() {
   return (
     <div className="space-y-6">
       <nav className="text-sm text-muted-foreground">
-        <Link href="/" className="hover:text-foreground">
-          Applications
+        <Link href="/opportunities" className="hover:text-foreground">
+          Opportunities
         </Link>
         <span className="mx-1.5">&rsaquo;</span>
         <span className="text-foreground font-medium">Create Opportunity</span>

--- a/src/app/opportunities/page.tsx
+++ b/src/app/opportunities/page.tsx
@@ -1,0 +1,47 @@
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { OpportunityTable } from "@/components/opportunity-table";
+import { StatusFilter } from "@/components/status-filter";
+import { listOpportunities, getStatusCounts } from "@/lib/actions/opportunities";
+import type { Status } from "@/lib/constants";
+
+interface PageProps {
+  searchParams: Promise<{ status?: string; archived?: string; search?: string }>;
+}
+
+export default async function OpportunitiesPage({ searchParams }: PageProps) {
+  const params = await searchParams;
+  const statusFilter = (params.status as Status | "all") ?? "all";
+  const showArchived = params.archived === "true";
+  const search = params.search || undefined;
+  const [opportunities, statusCounts] = await Promise.all([
+    listOpportunities(statusFilter, showArchived, search),
+    getStatusCounts(showArchived, search),
+  ]);
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h1 className="text-[1.875rem] font-bold tracking-[-0.025em] text-foreground">Opportunities</h1>
+          <p className="hidden sm:block text-sm font-medium text-muted-foreground mt-1">
+            Track and manage your professional journey through active
+            opportunities and historical records.
+          </p>
+        </div>
+        <Link href="/opportunities/new">
+          <Button>
+            Create
+          </Button>
+        </Link>
+      </div>
+
+      {/* Filters */}
+      <StatusFilter current={statusFilter} counts={statusCounts} searchParams={params} />
+
+      {/* Table */}
+      <OpportunityTable opportunities={opportunities} />
+    </div>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,47 +1,5 @@
-import Link from "next/link";
-import { Button } from "@/components/ui/button";
-import { OpportunityTable } from "@/components/opportunity-table";
-import { StatusFilter } from "@/components/status-filter";
-import { listOpportunities, getStatusCounts } from "@/lib/actions/opportunities";
-import type { Status } from "@/lib/constants";
+import { redirect } from "next/navigation";
 
-interface PageProps {
-  searchParams: Promise<{ status?: string; archived?: string; search?: string }>;
-}
-
-export default async function HomePage({ searchParams }: PageProps) {
-  const params = await searchParams;
-  const statusFilter = (params.status as Status | "all") ?? "all";
-  const showArchived = params.archived === "true";
-  const search = params.search || undefined;
-  const [opportunities, statusCounts] = await Promise.all([
-    listOpportunities(statusFilter, showArchived, search),
-    getStatusCounts(showArchived, search),
-  ]);
-
-  return (
-    <div className="space-y-6">
-      {/* Header */}
-      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-        <div>
-          <h1 className="text-[1.875rem] font-bold tracking-[-0.025em] text-foreground">Applications</h1>
-          <p className="hidden sm:block text-sm font-medium text-muted-foreground mt-1">
-            Track and manage your professional journey through active
-            opportunities and historical records.
-          </p>
-        </div>
-        <Link href="/opportunities/new">
-          <Button>
-            Create
-          </Button>
-        </Link>
-      </div>
-
-      {/* Filters */}
-      <StatusFilter current={statusFilter} counts={statusCounts} searchParams={params} />
-
-      {/* Table */}
-      <OpportunityTable opportunities={opportunities} />
-    </div>
-  );
+export default function RootPage() {
+  redirect("/opportunities");
 }

--- a/src/components/layout/app-shell.tsx
+++ b/src/components/layout/app-shell.tsx
@@ -16,13 +16,15 @@ export function AppShell({ children, user, authEnabled }: AppShellProps) {
 
   return (
     <div className="flex h-full">
-      <Sidebar
-        collapsed={collapsed}
-        onToggle={() => setCollapsed((c) => !c)}
-        authEnabled={authEnabled}
-        mobileOpen={mobileOpen}
-        onMobileClose={() => setMobileOpen(false)}
-      />
+      <Suspense fallback={<aside className="hidden md:block w-64 shrink-0 border-r" />}>
+        <Sidebar
+          collapsed={collapsed}
+          onToggle={() => setCollapsed((c) => !c)}
+          authEnabled={authEnabled}
+          mobileOpen={mobileOpen}
+          onMobileClose={() => setMobileOpen(false)}
+        />
+      </Suspense>
       <div className="flex flex-1 flex-col min-w-0">
         <Suspense fallback={<div className="h-14 shrink-0 border-b" />}>
           <TopBar

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { usePathname } from "next/navigation";
+import { usePathname, useSearchParams } from "next/navigation";
 import {
   LayoutDashboard,
   Briefcase,
@@ -18,9 +18,9 @@ import { signOutAction } from "@/lib/actions/auth";
 
 const navItems = [
   { href: "/dashboard", label: "Dashboard", icon: LayoutDashboard },
-  { href: "/", label: "Applications", icon: Briefcase },
+  { href: "/opportunities", label: "Opportunities", icon: Briefcase },
   { href: "/insights", label: "Insights", icon: BarChart3 },
-  { href: "/?archived=true", label: "Archive", icon: Archive },
+  { href: "/opportunities?archived=true", label: "Archive", icon: Archive },
 ];
 
 const bottomItems = [
@@ -35,12 +35,12 @@ interface SidebarProps {
   onMobileClose: () => void;
 }
 
-function isActive(pathname: string, search: string, href: string) {
-  if (href === "/") {
-    return pathname === "/" && !search.includes("archived=true");
+function isActive(pathname: string, archived: boolean, href: string) {
+  if (href === "/opportunities") {
+    return pathname === "/opportunities" && !archived;
   }
-  if (href === "/?archived=true") {
-    return search.includes("archived=true");
+  if (href === "/opportunities?archived=true") {
+    return pathname === "/opportunities" && archived;
   }
   return pathname.startsWith(href);
 }
@@ -90,13 +90,14 @@ export function Sidebar({
   onMobileClose,
 }: SidebarProps) {
   const pathname = usePathname();
-  const search = typeof window !== "undefined" ? window.location.search : "";
+  const searchParams = useSearchParams();
+  const archived = searchParams.get("archived") === "true";
 
   const sidebarContent = (
     <div className="flex h-full flex-col bg-sidebar text-sidebar-foreground">
       {/* Logo */}
       <div className="flex h-14 items-center border-b border-sidebar-border px-4">
-        <Link href="/" className="flex items-center gap-3" onClick={onMobileClose}>
+        <Link href="/opportunities" className="flex items-center gap-3" onClick={onMobileClose}>
           <Briefcase className="size-6 shrink-0 text-primary" />
           {!collapsed && (
             <div className="flex flex-col">
@@ -121,7 +122,7 @@ export function Sidebar({
           <NavLink
             key={item.href}
             {...item}
-            active={isActive(pathname, search, item.href)}
+            active={isActive(pathname, archived, item.href)}
             collapsed={collapsed}
             onClick={onMobileClose}
           />

--- a/src/components/layout/top-bar.tsx
+++ b/src/components/layout/top-bar.tsx
@@ -57,12 +57,13 @@ export function TopBar({ user, onMobileMenuClick }: TopBarProps) {
 
     const timer = setTimeout(() => {
       const params = new URLSearchParams(searchParams.toString());
+      params.delete("archived");
       if (trimmed) {
         params.set("search", trimmed);
       } else {
         params.delete("search");
       }
-      router.push(`/?${params.toString()}`);
+      router.push(`/opportunities?${params.toString()}`);
     }, 300);
 
     return () => clearTimeout(timer);
@@ -71,8 +72,9 @@ export function TopBar({ user, onMobileMenuClick }: TopBarProps) {
   const clearSearch = useCallback(() => {
     setValue("");
     const params = new URLSearchParams(searchParams.toString());
+    params.delete("archived");
     params.delete("search");
-    router.push(`/?${params.toString()}`);
+    router.push(`/opportunities?${params.toString()}`);
   }, [searchParams, router]);
 
   return (

--- a/src/components/layout/top-bar.tsx
+++ b/src/components/layout/top-bar.tsx
@@ -58,6 +58,7 @@ export function TopBar({ user, onMobileMenuClick }: TopBarProps) {
     const timer = setTimeout(() => {
       const params = new URLSearchParams(searchParams.toString());
       params.delete("archived");
+      params.delete("status");
       if (trimmed) {
         params.set("search", trimmed);
       } else {
@@ -73,6 +74,7 @@ export function TopBar({ user, onMobileMenuClick }: TopBarProps) {
     setValue("");
     const params = new URLSearchParams(searchParams.toString());
     params.delete("archived");
+    params.delete("status");
     params.delete("search");
     router.push(`/opportunities?${params.toString()}`);
   }, [searchParams, router]);

--- a/src/components/opportunity-actions.tsx
+++ b/src/components/opportunity-actions.tsx
@@ -25,13 +25,13 @@ export function OpportunitySidebarActions({
     } else {
       await archiveOpportunity(id);
     }
-    router.push("/");
+    router.push("/opportunities");
   };
 
   const handleDelete = async () => {
     if (!confirm("Delete this opportunity? This cannot be undone.")) return;
     await deleteOpportunity(id);
-    router.push("/");
+    router.push("/opportunities");
   };
 
   return (

--- a/src/components/opportunity-form.tsx
+++ b/src/components/opportunity-form.tsx
@@ -125,7 +125,7 @@ export function OpportunityForm({
   // Navigate on success
   useEffect(() => {
     if (!isEditing && "id" in createState && createState.id && !createState.errors) {
-      router.push("/");
+      router.push("/opportunities");
     }
   }, [createState, isEditing, router]);
 

--- a/src/components/status-filter.tsx
+++ b/src/components/status-filter.tsx
@@ -5,7 +5,7 @@ import { Button } from "@/components/ui/button";
 import { STATUSES, STATUS_LABELS, type Status } from "@/lib/constants";
 
 const filters: Array<{ value: Status | "all"; label: string }> = [
-  { value: "all", label: "All Apps" },
+  { value: "all", label: "All" },
   ...STATUSES.map((s) => ({ value: s, label: STATUS_LABELS[s] })),
 ];
 
@@ -29,7 +29,7 @@ export function StatusFilter({ current, counts, searchParams }: StatusFilterProp
     if (value !== "all") {
       params.set("status", value);
     }
-    router.push(`/?${params.toString()}`);
+    router.push(`/opportunities?${params.toString()}`);
   }
 
   return (

--- a/src/lib/actions/opportunities.ts
+++ b/src/lib/actions/opportunities.ts
@@ -44,11 +44,10 @@ export async function getStatusCounts(
   search?: string
 ): Promise<Record<string, number>> {
   const userId = await requireUserId();
-  const conditions = [eq(opportunities.userId, userId)];
-
-  if (!showArchived) {
-    conditions.push(eq(opportunities.archived, 0));
-  }
+  const conditions = [
+    eq(opportunities.userId, userId),
+    eq(opportunities.archived, showArchived ? 1 : 0),
+  ];
 
   if (search) {
     const escaped = search.replace(/[%_\\]/g, "\\$&");
@@ -80,11 +79,10 @@ export async function listOpportunities(
   search?: string
 ) {
   const userId = await requireUserId();
-  const conditions = [eq(opportunities.userId, userId)];
-
-  if (!showArchived) {
-    conditions.push(eq(opportunities.archived, 0));
-  }
+  const conditions = [
+    eq(opportunities.userId, userId),
+    eq(opportunities.archived, showArchived ? 1 : 0),
+  ];
 
   if (statusFilter && statusFilter !== "all") {
     conditions.push(eq(opportunities.status, statusFilter));
@@ -201,7 +199,7 @@ export async function createOpportunity(
 
   await recordStatusChange(id, data.status);
 
-  revalidatePath("/");
+  revalidatePath("/opportunities");
   return { id };
 }
 
@@ -263,7 +261,7 @@ export async function updateOpportunity(
     await recordStatusChange(id, data.status);
   }
 
-  revalidatePath("/");
+  revalidatePath("/opportunities");
   revalidatePath(`/opportunities/${id}`);
   return {};
 }
@@ -297,7 +295,7 @@ export async function updateOpportunityStatus(id: string, status: Status) {
 
   await recordStatusChange(id, status);
 
-  revalidatePath("/");
+  revalidatePath("/opportunities");
   revalidatePath(`/opportunities/${id}`);
 }
 
@@ -312,7 +310,7 @@ export async function archiveOpportunity(id: string) {
     })
     .where(and(eq(opportunities.id, id), eq(opportunities.userId, userId)));
 
-  revalidatePath("/");
+  revalidatePath("/opportunities");
 }
 
 export async function unarchiveOpportunity(id: string) {
@@ -326,7 +324,7 @@ export async function unarchiveOpportunity(id: string) {
     })
     .where(and(eq(opportunities.id, id), eq(opportunities.userId, userId)));
 
-  revalidatePath("/");
+  revalidatePath("/opportunities");
 }
 
 export async function deleteOpportunity(id: string) {
@@ -336,5 +334,5 @@ export async function deleteOpportunity(id: string) {
     .delete(opportunities)
     .where(and(eq(opportunities.id, id), eq(opportunities.userId, userId)));
 
-  revalidatePath("/");
+  revalidatePath("/opportunities");
 }


### PR DESCRIPTION
## Summary
- Move the opportunity list from `/` to `/opportunities`; `/` is now a server-side redirect.
- Rename the user-facing label "Applications" → "Opportunities" throughout the UI (sidebar, page header, breadcrumbs, filter pill).
- Fix a sidebar hydration mismatch by reading search params via `useSearchParams` and wrapping `Sidebar` in a Suspense boundary (matches the existing `TopBar` pattern).
- Re-apply the archive filter fix so the Archive tab shows only archived opportunities — the original fix lived on a feature branch that was squash-merged without including it.
- Top-bar search always targets the non-archived list now (strips `archived` from the pushed URL).

Closes #16

## Test plan
- [ ] Visit `/` — server redirects to `/opportunities`
- [ ] `/opportunities` shows non-archived opportunities with correct sidebar active state
- [ ] `/opportunities?archived=true` shows **only** archived opportunities with correct sidebar active state
- [ ] No hydration warnings in the browser console on any route
- [ ] Top-bar search from the archive view moves the user to the non-archived list with the search applied
- [ ] Create, archive/unarchive, and delete all redirect to `/opportunities`
- [ ] Breadcrumbs on `/opportunities/new`, `/opportunities/[id]`, and `/opportunities/[id]/edit` link back to `/opportunities` with the label "Opportunities"
- [ ] `/opportunities/new`, `/opportunities/[id]`, and `/opportunities/[id]/edit` continue to work unchanged
- [ ] `/dashboard` still renders its placeholder

🤖 Generated with [Claude Code](https://claude.com/claude-code)