### PR TITLE
Confirm before deleting an opportunity

### DIFF
--- a/src/components/confirm-dialog.tsx
+++ b/src/components/confirm-dialog.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+
+type ButtonVariant =
+  | "default"
+  | "outline"
+  | "secondary"
+  | "ghost"
+  | "destructive"
+  | "link";
+
+interface ConfirmDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  title: string;
+  description: string;
+  confirmLabel: string;
+  cancelLabel?: string;
+  confirmVariant?: ButtonVariant;
+  onConfirm: () => void | Promise<void>;
+}
+
+export function ConfirmDialog({
+  open,
+  onOpenChange,
+  title,
+  description,
+  confirmLabel,
+  cancelLabel = "Cancel",
+  confirmVariant = "default",
+  onConfirm,
+}: ConfirmDialogProps) {
+  const [pending, setPending] = useState(false);
+
+  const handleConfirm = async () => {
+    setPending(true);
+    try {
+      await onConfirm();
+      onOpenChange(false);
+    } finally {
+      setPending(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>{description}</DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={pending}
+          >
+            {cancelLabel}
+          </Button>
+          <Button
+            variant={confirmVariant}
+            onClick={handleConfirm}
+            disabled={pending}
+          >
+            {confirmLabel}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/opportunity-actions.tsx
+++ b/src/components/opportunity-actions.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { Archive, ArchiveRestore, Trash2 } from "lucide-react";
 import {
@@ -7,6 +8,7 @@ import {
   unarchiveOpportunity,
   deleteOpportunity,
 } from "@/lib/actions/opportunities";
+import { ConfirmDialog } from "@/components/confirm-dialog";
 
 interface OpportunitySidebarActionsProps {
   id: string;
@@ -18,6 +20,7 @@ export function OpportunitySidebarActions({
   archived,
 }: OpportunitySidebarActionsProps) {
   const router = useRouter();
+  const [confirmOpen, setConfirmOpen] = useState(false);
 
   const handleArchiveToggle = async () => {
     if (archived) {
@@ -29,7 +32,6 @@ export function OpportunitySidebarActions({
   };
 
   const handleDelete = async () => {
-    if (!confirm("Delete this opportunity? This cannot be undone.")) return;
     await deleteOpportunity(id);
     router.push("/opportunities");
   };
@@ -51,13 +53,22 @@ export function OpportunitySidebarActions({
         </button>
         <button
           type="button"
-          onClick={handleDelete}
+          onClick={() => setConfirmOpen(true)}
           className="flex items-center gap-2 rounded-md px-2 py-1.5 text-sm text-destructive hover:bg-destructive/10 transition-colors w-full"
         >
           <Trash2 className="size-4" />
           Delete opportunity
         </button>
       </div>
+      <ConfirmDialog
+        open={confirmOpen}
+        onOpenChange={setConfirmOpen}
+        title="Delete Opportunity?"
+        description="This cannot be undone."
+        confirmLabel="Delete"
+        confirmVariant="destructive"
+        onConfirm={handleDelete}
+      />
     </div>
   );
 }

--- a/src/components/opportunity-table.tsx
+++ b/src/components/opportunity-table.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import {
@@ -24,6 +25,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { ConfirmDialog } from "@/components/confirm-dialog";
 import { StatusBadge } from "@/components/status-badge";
 import {
   archiveOpportunity,
@@ -79,41 +81,54 @@ function ActionsMenu({
   opportunityId: string;
   router: ReturnType<typeof useRouter>;
 }) {
+  const [confirmOpen, setConfirmOpen] = useState(false);
+
   return (
-    <DropdownMenu>
-      <DropdownMenuTrigger className="p-1 rounded-md hover:bg-accent cursor-pointer">
-        <MoreHorizontal className="size-4" />
-      </DropdownMenuTrigger>
-      <DropdownMenuContent align="end">
-        <DropdownMenuItem
-          onClick={() => router.push(`/opportunities/${opportunityId}`)}
-        >
-          <Eye className="size-4 mr-2" />
-          View
-        </DropdownMenuItem>
-        <DropdownMenuItem
-          onClick={() =>
-            router.push(`/opportunities/${opportunityId}/edit`)
-          }
-        >
-          <Pencil className="size-4 mr-2" />
-          Edit
-        </DropdownMenuItem>
-        <DropdownMenuItem
-          onClick={() => archiveOpportunity(opportunityId)}
-        >
-          <Archive className="size-4 mr-2" />
-          Archive
-        </DropdownMenuItem>
-        <DropdownMenuItem
-          className="text-destructive"
-          onClick={() => deleteOpportunity(opportunityId)}
-        >
-          <Trash2 className="size-4 mr-2" />
-          Delete
-        </DropdownMenuItem>
-      </DropdownMenuContent>
-    </DropdownMenu>
+    <>
+      <DropdownMenu>
+        <DropdownMenuTrigger className="p-1 rounded-md hover:bg-accent cursor-pointer">
+          <MoreHorizontal className="size-4" />
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          <DropdownMenuItem
+            onClick={() => router.push(`/opportunities/${opportunityId}`)}
+          >
+            <Eye className="size-4 mr-2" />
+            View
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            onClick={() =>
+              router.push(`/opportunities/${opportunityId}/edit`)
+            }
+          >
+            <Pencil className="size-4 mr-2" />
+            Edit
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            onClick={() => archiveOpportunity(opportunityId)}
+          >
+            <Archive className="size-4 mr-2" />
+            Archive
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            className="text-destructive"
+            onClick={() => setConfirmOpen(true)}
+          >
+            <Trash2 className="size-4 mr-2" />
+            Delete
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+      <ConfirmDialog
+        open={confirmOpen}
+        onOpenChange={setConfirmOpen}
+        title="Delete Opportunity?"
+        description="This cannot be undone."
+        confirmLabel="Delete"
+        confirmVariant="destructive"
+        onConfirm={() => deleteOpportunity(opportunityId)}
+      />
+    </>
   );
 }
 


### PR DESCRIPTION
## Summary
- Add a reusable `ConfirmDialog` component built on the existing `@base-ui/react` Dialog primitive.
- Wire it into both delete entry points: the table row's actions dropdown ([src/components/opportunity-table.tsx](src/components/opportunity-table.tsx)) and the detail page sidebar ([src/components/opportunity-actions.tsx](src/components/opportunity-actions.tsx)).
- Remove the browser-native `confirm()` that was previously used on the detail page.
- Leave archive actions as-is — they're reversible via unarchive, so an extra click would annoy more than it protects.

Closes #13

## Test plan
- [ ] Desktop table: clicking Delete in a row's dropdown opens the dialog. Cancel dismisses. Delete actually deletes and the row disappears.
- [ ] Mobile card view: same behavior as desktop.
- [ ] Detail page sidebar: clicking "Delete opportunity" opens the new dialog (not the browser-native prompt). Cancel dismisses. Delete deletes and redirects to `/opportunities`.
- [ ] Archive (both table row and detail sidebar) continues to fire immediately with no dialog.
- [ ] During the confirmation delete, Cancel and Delete buttons are disabled (pending state).
- [ ] No console errors/warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)