### PR TITLE
Edit and delete opportunity comments

### DIFF
--- a/src/components/comment-actions-menu.tsx
+++ b/src/components/comment-actions-menu.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { MoreHorizontal, type LucideIcon } from "lucide-react";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+
+export type CommentAction = {
+  label: string;
+  icon?: LucideIcon;
+  onSelect: () => void;
+  destructive?: boolean;
+};
+
+interface CommentActionsMenuProps {
+  actions: CommentAction[];
+  ariaLabel?: string;
+}
+
+export function CommentActionsMenu({
+  actions,
+  ariaLabel = "Comment actions",
+}: CommentActionsMenuProps) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger
+        aria-label={ariaLabel}
+        className="flex h-6 w-6 items-center justify-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
+      >
+        <MoreHorizontal className="size-4" />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        {actions.map((action) => {
+          const Icon = action.icon;
+          return (
+            <DropdownMenuItem
+              key={action.label}
+              onClick={action.onSelect}
+              variant={action.destructive ? "destructive" : "default"}
+            >
+              {Icon && <Icon className="size-4 mr-2" />}
+              {action.label}
+            </DropdownMenuItem>
+          );
+        })}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/src/components/comment-editor.tsx
+++ b/src/components/comment-editor.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+
+interface CommentEditorProps {
+  initialBody: string;
+  onSave: (body: string) => Promise<void>;
+  onCancel: () => void;
+}
+
+export function CommentEditor({
+  initialBody,
+  onSave,
+  onCancel,
+}: CommentEditorProps) {
+  const [body, setBody] = useState(initialBody);
+  const [error, setError] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  const trimmed = body.trim();
+  const canSave =
+    trimmed.length > 0 && trimmed !== initialBody.trim() && !isPending;
+
+  function handleSave() {
+    if (!canSave) return;
+    setError(null);
+    startTransition(async () => {
+      try {
+        await onSave(trimmed);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Failed to update comment");
+      }
+    });
+  }
+
+  return (
+    <div>
+      <Textarea
+        value={body}
+        onChange={(e) => setBody(e.target.value)}
+        rows={4}
+        disabled={isPending}
+        className="resize-y"
+        autoFocus
+      />
+      {error && <p className="mt-2 text-sm text-destructive">{error}</p>}
+      <div className="mt-2 flex items-center justify-end gap-2">
+        <Button
+          type="button"
+          variant="outline"
+          onClick={onCancel}
+          disabled={isPending}
+        >
+          Cancel
+        </Button>
+        <Button type="button" onClick={handleSave} disabled={!canSave}>
+          {isPending ? "Saving..." : "Save"}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/comment-editor.tsx
+++ b/src/components/comment-editor.tsx
@@ -17,11 +17,13 @@ export function CommentEditor({
 }: CommentEditorProps) {
   const [body, setBody] = useState(initialBody);
   const [error, setError] = useState<string | null>(null);
+  const [saved, setSaved] = useState(false);
   const [isPending, startTransition] = useTransition();
 
   const trimmed = body.trim();
+  const busy = isPending || saved;
   const canSave =
-    trimmed.length > 0 && trimmed !== initialBody.trim() && !isPending;
+    trimmed.length > 0 && trimmed !== initialBody.trim() && !busy;
 
   function handleSave() {
     if (!canSave) return;
@@ -29,6 +31,7 @@ export function CommentEditor({
     startTransition(async () => {
       try {
         await onSave(trimmed);
+        setSaved(true);
       } catch (err) {
         setError(err instanceof Error ? err.message : "Failed to update comment");
       }
@@ -41,7 +44,7 @@ export function CommentEditor({
         value={body}
         onChange={(e) => setBody(e.target.value)}
         rows={4}
-        disabled={isPending}
+        disabled={busy}
         className="resize-y"
         autoFocus
       />
@@ -51,12 +54,12 @@ export function CommentEditor({
           type="button"
           variant="outline"
           onClick={onCancel}
-          disabled={isPending}
+          disabled={busy}
         >
           Cancel
         </Button>
         <Button type="button" onClick={handleSave} disabled={!canSave}>
-          {isPending ? "Saving..." : "Save"}
+          {busy ? "Saving..." : "Save"}
         </Button>
       </div>
     </div>

--- a/src/components/opportunity-timeline.tsx
+++ b/src/components/opportunity-timeline.tsx
@@ -1,6 +1,6 @@
 import { MessageSquare } from "lucide-react";
-import { Markdown } from "@/components/markdown";
 import { CommentComposer } from "@/components/comment-composer";
+import { TimelineComment } from "@/components/timeline-comment";
 import {
   STATUS_LABELS,
   STATUS_DOT_COLORS,
@@ -21,6 +21,8 @@ type TimelineEvent =
       id: string;
       timestamp: string;
       body: string;
+      createdAt: string;
+      updatedAt: string;
     };
 
 // On exact timestamp ties, structural events (status changes) render before
@@ -47,6 +49,8 @@ function buildEvents(
     id: entry.id,
     timestamp: entry.createdAt,
     body: entry.body,
+    createdAt: entry.createdAt,
+    updatedAt: entry.updatedAt,
   }));
 
   return [...statusEvents, ...commentEvents].sort((a, b) => {
@@ -119,39 +123,6 @@ function StatusEvent({
   );
 }
 
-function CommentEvent({
-  body,
-  timestamp,
-}: {
-  body: string;
-  timestamp: string;
-}) {
-  return (
-    <li className="relative pl-8">
-      <span
-        aria-hidden
-        className="absolute left-4 top-2 -translate-x-1/2 flex h-5 w-5 items-center justify-center rounded-full bg-muted text-muted-foreground ring-4 ring-background"
-      >
-        <MessageSquare className="h-3 w-3" />
-      </span>
-      <div className="rounded-lg border bg-card">
-        <header className="flex items-center justify-between border-b px-4 py-2">
-          <time
-            dateTime={timestamp}
-            title={formatAbsolute(timestamp)}
-            className="text-xs text-muted-foreground"
-          >
-            commented {formatRelative(timestamp)}
-          </time>
-        </header>
-        <div className="px-4 py-3">
-          <Markdown>{body}</Markdown>
-        </div>
-      </div>
-    </li>
-  );
-}
-
 export function OpportunityTimeline({
   opportunityId,
   history,
@@ -180,10 +151,12 @@ export function OpportunityTimeline({
                 note={event.note}
               />
             ) : (
-              <CommentEvent
+              <TimelineComment
                 key={`comment-${event.id}`}
+                id={event.id}
                 body={event.body}
-                timestamp={event.timestamp}
+                createdAt={event.createdAt}
+                updatedAt={event.updatedAt}
               />
             )
           )}

--- a/src/components/timeline-comment.tsx
+++ b/src/components/timeline-comment.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import { useState } from "react";
+import { MessageSquare, Pencil, Trash2 } from "lucide-react";
+import { Markdown } from "@/components/markdown";
+import { CommentEditor } from "@/components/comment-editor";
+import {
+  CommentActionsMenu,
+  type CommentAction,
+} from "@/components/comment-actions-menu";
+import { ConfirmDialog } from "@/components/confirm-dialog";
+import { updateComment, deleteComment } from "@/lib/actions/opportunities";
+
+function formatAbsolute(timestamp: string) {
+  return new Date(timestamp).toLocaleString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
+function formatRelative(timestamp: string) {
+  const then = new Date(timestamp).getTime();
+  const now = Date.now();
+  const diffMs = now - then;
+  const minutes = Math.round(diffMs / 60_000);
+  if (minutes < 1) return "just now";
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.round(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.round(hours / 24);
+  if (days < 30) return `${days}d ago`;
+  const months = Math.round(days / 30);
+  if (months < 12) return `${months}mo ago`;
+  const years = Math.round(months / 12);
+  return `${years}y ago`;
+}
+
+interface TimelineCommentProps {
+  id: string;
+  body: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export function TimelineComment({
+  id,
+  body,
+  createdAt,
+  updatedAt,
+}: TimelineCommentProps) {
+  const [mode, setMode] = useState<"view" | "edit">("view");
+  const [confirmDeleteOpen, setConfirmDeleteOpen] = useState(false);
+
+  const edited = updatedAt !== createdAt;
+
+  const actions: CommentAction[] = [
+    {
+      label: "Edit",
+      icon: Pencil,
+      onSelect: () => setMode("edit"),
+    },
+    {
+      label: "Delete",
+      icon: Trash2,
+      onSelect: () => setConfirmDeleteOpen(true),
+      destructive: true,
+    },
+  ];
+
+  async function handleSave(newBody: string) {
+    await updateComment(id, newBody);
+    setMode("view");
+  }
+
+  return (
+    <li className="relative pl-8">
+      <span
+        aria-hidden
+        className="absolute left-4 top-2 -translate-x-1/2 flex h-5 w-5 items-center justify-center rounded-full bg-muted text-muted-foreground ring-4 ring-background"
+      >
+        <MessageSquare className="h-3 w-3" />
+      </span>
+      <div className="rounded-lg border bg-card">
+        <header className="flex items-center justify-between border-b px-4 py-2">
+          <div className="flex items-baseline gap-1.5">
+            <time
+              dateTime={createdAt}
+              title={formatAbsolute(createdAt)}
+              className="text-xs text-muted-foreground"
+            >
+              commented {formatRelative(createdAt)}
+            </time>
+            {edited && (
+              <span
+                title={`Edited ${formatAbsolute(updatedAt)}`}
+                className="text-xs text-muted-foreground"
+              >
+                (edited)
+              </span>
+            )}
+          </div>
+          {mode === "view" && <CommentActionsMenu actions={actions} />}
+        </header>
+        <div className="px-4 py-3">
+          {mode === "edit" ? (
+            <CommentEditor
+              initialBody={body}
+              onSave={handleSave}
+              onCancel={() => setMode("view")}
+            />
+          ) : (
+            <Markdown>{body}</Markdown>
+          )}
+        </div>
+      </div>
+      <ConfirmDialog
+        open={confirmDeleteOpen}
+        onOpenChange={setConfirmDeleteOpen}
+        title="Delete comment"
+        description="Are you sure you'd like to delete this comment?"
+        confirmLabel="Delete"
+        confirmVariant="destructive"
+        onConfirm={() => deleteComment(id)}
+      />
+    </li>
+  );
+}

--- a/src/lib/actions/opportunities.ts
+++ b/src/lib/actions/opportunities.ts
@@ -154,11 +154,20 @@ export async function addComment(opportunityId: string, body: string) {
   revalidatePath(`/opportunities/${opportunityId}`);
 }
 
-async function getCommentOpportunityId(commentId: string) {
+async function getOwnedCommentOpportunityId(commentId: string, userId: string) {
   const rows = await db
     .select({ opportunityId: opportunityComments.opportunityId })
     .from(opportunityComments)
-    .where(eq(opportunityComments.id, commentId))
+    .innerJoin(
+      opportunities,
+      eq(opportunities.id, opportunityComments.opportunityId)
+    )
+    .where(
+      and(
+        eq(opportunityComments.id, commentId),
+        eq(opportunities.userId, userId)
+      )
+    )
     .limit(1);
 
   if (!rows[0]) {
@@ -169,8 +178,7 @@ async function getCommentOpportunityId(commentId: string) {
 
 export async function updateComment(commentId: string, body: string) {
   const userId = await requireUserId();
-  const opportunityId = await getCommentOpportunityId(commentId);
-  await assertOpportunityOwnership(opportunityId, userId);
+  const opportunityId = await getOwnedCommentOpportunityId(commentId, userId);
 
   const trimmed = body.trim();
   if (!trimmed) {
@@ -187,8 +195,7 @@ export async function updateComment(commentId: string, body: string) {
 
 export async function deleteComment(commentId: string) {
   const userId = await requireUserId();
-  const opportunityId = await getCommentOpportunityId(commentId);
-  await assertOpportunityOwnership(opportunityId, userId);
+  const opportunityId = await getOwnedCommentOpportunityId(commentId, userId);
 
   await db
     .delete(opportunityComments)

--- a/src/lib/actions/opportunities.ts
+++ b/src/lib/actions/opportunities.ts
@@ -154,6 +154,49 @@ export async function addComment(opportunityId: string, body: string) {
   revalidatePath(`/opportunities/${opportunityId}`);
 }
 
+async function getCommentOpportunityId(commentId: string) {
+  const rows = await db
+    .select({ opportunityId: opportunityComments.opportunityId })
+    .from(opportunityComments)
+    .where(eq(opportunityComments.id, commentId))
+    .limit(1);
+
+  if (!rows[0]) {
+    throw new Error("Comment not found");
+  }
+  return rows[0].opportunityId;
+}
+
+export async function updateComment(commentId: string, body: string) {
+  const userId = await requireUserId();
+  const opportunityId = await getCommentOpportunityId(commentId);
+  await assertOpportunityOwnership(opportunityId, userId);
+
+  const trimmed = body.trim();
+  if (!trimmed) {
+    throw new Error("Comment cannot be empty");
+  }
+
+  await db
+    .update(opportunityComments)
+    .set({ body: trimmed, updatedAt: new Date().toISOString() })
+    .where(eq(opportunityComments.id, commentId));
+
+  revalidatePath(`/opportunities/${opportunityId}`);
+}
+
+export async function deleteComment(commentId: string) {
+  const userId = await requireUserId();
+  const opportunityId = await getCommentOpportunityId(commentId);
+  await assertOpportunityOwnership(opportunityId, userId);
+
+  await db
+    .delete(opportunityComments)
+    .where(eq(opportunityComments.id, commentId));
+
+  revalidatePath(`/opportunities/${opportunityId}`);
+}
+
 export async function createOpportunity(
   prevState: OpportunityFormState,
   formData: FormData


### PR DESCRIPTION
## Summary
Comments on the opportunity detail timeline now support edit and delete via a GitHub-style kebab (horizontal three-dot) menu in the comment's header.

- **Edit** swaps the body for an inline textarea with Save/Cancel. Save is gated on a non-empty body that actually changed.
- **Delete** opens a confirmation dialog (reuses `ConfirmDialog` from #34).
- **Edited comments** show `(edited)` next to the timestamp, with the edit time on hover.
- **Kebab menu is generic** — `CommentActionsMenu` accepts an `actions: { label, icon?, onSelect, destructive? }[]` array so future items (quote reply, copy link, report) drop in without refactoring.

Adds two server actions — `updateComment` and `deleteComment` — both of which re-verify the parent opportunity's ownership via the existing `assertOpportunityOwnership` helper rather than trusting the comment row alone. Both call `revalidatePath` on the detail page.

Closes #28

## Test plan
- [ ] Comments render as before when unedited (no `(edited)` indicator).
- [ ] Kebab → Edit swaps the body for a textarea with Save and Cancel. Save is disabled when empty or unchanged.
- [ ] After saving, the comment body updates and shows `(edited)` with the edit time visible on hover via the `title` attribute.
- [ ] Cancel restores the original body.
- [ ] Kebab → Delete opens a dialog titled "Delete comment" with the description "Are you sure you'd like to delete this comment?" Cancel dismisses. Delete removes the comment from the timeline.
- [ ] Status events continue to render without a kebab menu.
- [ ] Empty state still renders the composer correctly.
- [ ] The "Commenting…" / "Saving…" pending states appear briefly during async work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)