### PR TITLE
Submit forms with Cmd/Ctrl+Enter

### DIFF
--- a/src/components/comment-composer.tsx
+++ b/src/components/comment-composer.tsx
@@ -33,6 +33,7 @@ export function CommentComposer({ opportunityId }: { opportunityId: string }) {
         onChange={setBody}
         placeholder="Use Markdown to format your comment"
         disabled={isPending}
+        onSubmit={handleSubmit}
       />
       {error && <p className="mt-2 text-sm text-destructive">{error}</p>}
       <div className="mt-3 flex items-center justify-end">

--- a/src/components/comment-editor.tsx
+++ b/src/components/comment-editor.tsx
@@ -45,6 +45,7 @@ export function CommentEditor({
         onChange={setBody}
         disabled={busy}
         autoFocus
+        onSubmit={handleSave}
       />
       {error && <p className="mt-2 text-sm text-destructive">{error}</p>}
       <div className="mt-2 flex items-center justify-end gap-2">

--- a/src/components/markdown-editor.tsx
+++ b/src/components/markdown-editor.tsx
@@ -66,6 +66,7 @@ interface MarkdownEditorProps {
   disabled?: boolean;
   minHeight?: number;
   autoFocus?: boolean;
+  onSubmit?: () => void;
 }
 
 export function MarkdownEditor({
@@ -75,6 +76,7 @@ export function MarkdownEditor({
   disabled,
   minHeight = 140,
   autoFocus,
+  onSubmit,
 }: MarkdownEditorProps) {
   const [tab, setTab] = useState<Tab>("write");
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
@@ -100,6 +102,18 @@ export function MarkdownEditor({
   }, [tab, autoFocus]);
 
   function onKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
+    if (
+      e.key === "Enter" &&
+      !e.shiftKey &&
+      (e.metaKey || e.ctrlKey) &&
+      onSubmit
+    ) {
+      e.preventDefault();
+      e.stopPropagation();
+      onSubmit();
+      return;
+    }
+
     if (e.key === "Enter" && !e.shiftKey) {
       const target = e.currentTarget;
       const { selectionStart, value: current } = target;

--- a/src/components/opportunity-form.tsx
+++ b/src/components/opportunity-form.tsx
@@ -130,10 +130,10 @@ export function OpportunityForm({
   }, [createState, isEditing, router]);
 
   useEffect(() => {
-    if (isEditing && updateState && !updateState.errors && !updatePending && Object.keys(updateState).length > 0 && !updateState.message) {
+    if (isEditing && "id" in updateState && updateState.id && !updateState.errors) {
       router.push(`/opportunities/${opportunity!.id}`);
     }
-  }, [updateState, isEditing, updatePending, opportunity, router]);
+  }, [updateState, isEditing, opportunity, router]);
 
   const handleChange = useCallback(
     (field: string) => (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
@@ -224,8 +224,49 @@ export function OpportunityForm({
     });
   }, [aiInputMode, aiInputValue, applyParsedValues]);
 
+  const submitDisabled =
+    pending || !values.company.trim() || !values.role.trim();
+
+  const handleFormKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLFormElement>) => {
+      if (e.key !== "Enter" || e.shiftKey || !(e.metaKey || e.ctrlKey)) {
+        return;
+      }
+
+      const target = e.target as HTMLElement | null;
+      const inAiPanel =
+        target instanceof HTMLElement &&
+        (target.id === "ai-url" || target.id === "ai-text");
+
+      if (inAiPanel) {
+        if (aiEnabled && !isEditing && !isParsing && aiInputValue.trim()) {
+          e.preventDefault();
+          handleAutoFill();
+        }
+        return;
+      }
+
+      if (submitDisabled) return;
+      e.preventDefault();
+      formRef.current?.requestSubmit();
+    },
+    [
+      aiEnabled,
+      aiInputValue,
+      handleAutoFill,
+      isEditing,
+      isParsing,
+      submitDisabled,
+    ]
+  );
+
   return (
-    <form ref={formRef} action={formAction} className="space-y-6 max-w-2xl">
+    <form
+      ref={formRef}
+      action={formAction}
+      onKeyDown={handleFormKeyDown}
+      className="space-y-6 max-w-2xl"
+    >
       {state.message && state.errors && (
         <div className="rounded-md bg-destructive/10 p-3 text-sm text-destructive">
           {state.message}
@@ -539,7 +580,7 @@ export function OpportunityForm({
       </div>
 
       <div className="flex gap-3">
-        <Button type="submit" disabled={pending || !values.company.trim() || !values.role.trim()}>
+        <Button type="submit" disabled={submitDisabled}>
           {pending ? (isEditing ? "Saving..." : "Creating...") : (isEditing ? "Save" : "Create")}
         </Button>
         <Button type="button" variant="outline" onClick={() => router.back()}>

--- a/src/lib/actions/opportunities.ts
+++ b/src/lib/actions/opportunities.ts
@@ -313,7 +313,7 @@ export async function updateOpportunity(
 
   revalidatePath("/opportunities");
   revalidatePath(`/opportunities/${id}`);
-  return {};
+  return { id };
 }
 
 export async function updateOpportunityStatus(id: string, status: Status) {

--- a/src/lib/validations/opportunity.ts
+++ b/src/lib/validations/opportunity.ts
@@ -149,6 +149,7 @@ export type OpportunityFormErrors = {
 export type OpportunityFormState = {
   errors?: OpportunityFormErrors;
   message?: string;
+  id?: string;
 };
 
 function getOptionalFormValue(formData: FormData, key: string) {


### PR DESCRIPTION
## Summary

- Adds `Cmd+Enter` (macOS) / `Ctrl+Enter` (Win/Linux) keyboard shortcut to submit the comment composer, comment editor (edit mode), and the opportunity create/edit form, matching GitHub's convention.
- Inside the AI auto-fill panel the same shortcut triggers **Auto-fill** instead of submitting the form, so users don't accidentally create a partial opportunity while typing a job URL/description.
- Fixes a pre-existing bug where saving an opportunity edit kept the user on `/opportunities/{id}/edit`. `updateOpportunity` now returns `{ id }` on success and the redirect effect mirrors the create flow.

Closes #43.

## Test plan

- [x] Comment composer: Ctrl+Enter posts the comment; empty composer ignores the shortcut (button is disabled)
- [x] Comment editor: Ctrl+Enter saves the edit and closes the editor
- [x] Opportunity edit form: Ctrl+Enter saves and redirects to `/opportunities/{id}`
- [x] Opportunity edit form: clicking **Save** also redirects (regression fix)
- [x] Opportunity new form: Ctrl+Enter creates with valid Company/Role; no-op when either is empty
- [x] AI auto-fill panel: Ctrl+Enter inside the URL/text input triggers Auto-fill, not form submit (requires `AI_PROVIDER`/`FIRECRAWL_API_KEY`)
- [x] `Shift+Enter` still inserts a newline in the markdown editor
- [x] Plain `Enter` still collapses empty list markers in the markdown editor

🤖 Generated with [Claude Code](https://claude.com/claude-code)