### PR TITLE
Adopt Vercel AI Gateway for model calls and observability

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,15 +29,13 @@ ALLOWED_USERS=
 TURSO_DATABASE_URL=
 TURSO_AUTH_TOKEN=
 
-# Optional AI job posting parser
-# Supported providers: openai, anthropic, google
-AI_PROVIDER=
+# Optional AI job posting parser — routes through Vercel AI Gateway
+# Get an API key from the Vercel dashboard: https://vercel.com/dashboard/ai-gateway
+# AI_MODEL uses the "provider/model" format, e.g.:
+#   anthropic/claude-sonnet-4.6, openai/gpt-4.1-mini, google/gemini-2.5-flash
+AI_GATEWAY_API_KEY=
 AI_MODEL=
 AI_PARSE_TIMEOUT_MS=30000
-AI_PARSER_DEBUG=false
-OPENAI_API_KEY=
-ANTHROPIC_API_KEY=
-GOOGLE_GENERATIVE_AI_API_KEY=
 
 # Optional Firecrawl URL parsing
 FIRECRAWL_API_KEY=

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,7 @@ Feature backlog is tracked in GitHub Issues: https://github.com/zachradtka/oppor
 - URL parsing uses Firecrawl when `FIRECRAWL_API_KEY` is configured
 - Pasted-text parsing routes through [Vercel AI Gateway](https://vercel.com/docs/ai-gateway) when `AI_GATEWAY_API_KEY` and `AI_MODEL` are set
 - Get the gateway API key from the Vercel dashboard. The gateway provides centralized observability (request logs, latency, token usage) for every model call
+- Gateway usage is billed through your Vercel account by default; configure BYOK in the Gateway dashboard to bill against your own provider keys instead
 - `AI_MODEL` uses the `provider/model` format, e.g. `anthropic/claude-sonnet-4.6`, `openai/gpt-4.1-mini`, `google/gemini-2.5-flash` — switch models by editing this single string
 - Optional: set `AI_PARSE_TIMEOUT_MS` to control how long a parse call can run before it fails
 - Optional Firecrawl settings:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,18 +56,13 @@ Feature backlog is tracked in GitHub Issues: https://github.com/zachradtka/oppor
 ## AI Parsing
 
 - URL parsing uses Firecrawl when `FIRECRAWL_API_KEY` is configured
-- Pasted-text parsing uses the configured AI provider when `AI_PROVIDER` is set to a supported provider and the matching API key is present
-- Supported providers today: `openai`, `anthropic`, `google`
-- Optional: set `AI_MODEL` to override the default model for the selected provider
+- Pasted-text parsing routes through [Vercel AI Gateway](https://vercel.com/docs/ai-gateway) when `AI_GATEWAY_API_KEY` and `AI_MODEL` are set
+- Get the gateway API key from the Vercel dashboard. The gateway provides centralized observability (request logs, latency, token usage) for every model call
+- `AI_MODEL` uses the `provider/model` format, e.g. `anthropic/claude-sonnet-4.6`, `openai/gpt-4.1-mini`, `google/gemini-2.5-flash` — switch models by editing this single string
 - Optional: set `AI_PARSE_TIMEOUT_MS` to control how long a parse call can run before it fails
-- Optional: set `AI_PARSER_DEBUG=true` for verbose server logs while debugging parser behavior locally
 - Optional Firecrawl settings:
   - `FIRECRAWL_API_URL` defaults to `https://api.firecrawl.dev/v2`
   - `FIRECRAWL_TIMEOUT_MS` controls the Firecrawl scrape timeout
   - `FIRECRAWL_MAX_AGE_MS` controls Firecrawl caching
   - `FIRECRAWL_PROXY` can be `basic`, `enhanced`, or `auto`
-- Required keys by provider:
-  - `OPENAI_API_KEY` when `AI_PROVIDER=openai`
-  - `ANTHROPIC_API_KEY` when `AI_PROVIDER=anthropic`
-  - `GOOGLE_GENERATIVE_AI_API_KEY` when `AI_PROVIDER=google`
-- When neither Firecrawl nor an AI provider is configured, the opportunity form renders exactly like the non-AI version
+- When neither Firecrawl nor the AI Gateway is configured, the opportunity form renders exactly like the non-AI version

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,6 @@
       "name": "opportunity-tracker",
       "version": "0.1.0",
       "dependencies": {
-        "@ai-sdk/anthropic": "^3.0.67",
-        "@ai-sdk/google": "^3.0.59",
-        "@ai-sdk/openai": "^3.0.51",
         "@auth/drizzle-adapter": "^1.11.2",
         "@base-ui/react": "^1.3.0",
         "@libsql/client": "^0.17.2",
@@ -51,22 +48,6 @@
         "typescript": "^5"
       }
     },
-    "node_modules/@ai-sdk/anthropic": {
-      "version": "3.0.67",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-3.0.67.tgz",
-      "integrity": "sha512-FFX4P5Fd6lcQJc2OLngZQkbbJHa0IDDZi087Edb8qRZx6h90krtM61ArbMUL8us/7ZUwojCXnyJ/wQ2Eflx2jQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ai-sdk/provider": "3.0.8",
-        "@ai-sdk/provider-utils": "4.0.23"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.76 || ^4.1.8"
-      }
-    },
     "node_modules/@ai-sdk/gateway": {
       "version": "3.0.91",
       "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.91.tgz",
@@ -76,38 +57,6 @@
         "@ai-sdk/provider": "3.0.8",
         "@ai-sdk/provider-utils": "4.0.23",
         "@vercel/oidc": "3.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.76 || ^4.1.8"
-      }
-    },
-    "node_modules/@ai-sdk/google": {
-      "version": "3.0.59",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/google/-/google-3.0.59.tgz",
-      "integrity": "sha512-N5pyd6xSIIguG45kM/hvWdTrmudOY/iZ07DZu12K5q/NSeapQQFOYg+3DRKONzS9+FESLugjjzFrzfA24sQ6lw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ai-sdk/provider": "3.0.8",
-        "@ai-sdk/provider-utils": "4.0.23"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.76 || ^4.1.8"
-      }
-    },
-    "node_modules/@ai-sdk/openai": {
-      "version": "3.0.51",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-3.0.51.tgz",
-      "integrity": "sha512-qBgDOC+vlXwLFbZ3UoKx3T8VFyul3K39JNyW6E4XnOnzLT4Mlhb0GeDC06RvYqwGWOQFBQNLe/vegOMVtNpl5g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ai-sdk/provider": "3.0.8",
-        "@ai-sdk/provider-utils": "4.0.23"
       },
       "engines": {
         "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -13,9 +13,6 @@
     "import": "tsx scripts/import-csv.ts"
   },
   "dependencies": {
-    "@ai-sdk/anthropic": "^3.0.67",
-    "@ai-sdk/google": "^3.0.59",
-    "@ai-sdk/openai": "^3.0.51",
     "@auth/drizzle-adapter": "^1.11.2",
     "@base-ui/react": "^1.3.0",
     "@libsql/client": "^0.17.2",

--- a/src/lib/actions/parse-job-posting.ts
+++ b/src/lib/actions/parse-job-posting.ts
@@ -2,11 +2,7 @@
 
 import { generateObject } from "ai";
 import * as z from "zod";
-import {
-  getAiLanguageModel,
-  getAiProviderConfig,
-  isAiParsingEnabled,
-} from "@/lib/ai";
+import { getAiModel, isAiParsingEnabled } from "@/lib/ai";
 import { requireUserId } from "@/lib/auth-optional";
 import { getFirecrawlConfig, isFirecrawlEnabled } from "@/lib/firecrawl";
 import {
@@ -153,21 +149,15 @@ function getParseTimeoutMs() {
     : DEFAULT_PARSE_TIMEOUT_MS;
 }
 
-function isParserDebugEnabled() {
-  return process.env.AI_PARSER_DEBUG === "true";
-}
+async function generateParsedTextPosting(input: Extract<ParseJobPostingInput, { sourceType: "text" }>) {
+  const model = getAiModel();
 
-function logParserDebug(message: string, details?: Record<string, unknown>) {
-  if (!isParserDebugEnabled()) {
-    return;
+  if (!model) {
+    throw new Error("AI parsing is not configured.");
   }
 
-  console.log(`[ai-parser] ${message}`, details ?? {});
-}
-
-async function generateParsedTextPosting(input: Extract<ParseJobPostingInput, { sourceType: "text" }>) {
   const result = await generateObject({
-    model: getAiLanguageModel(),
+    model,
     timeout: { totalMs: getParseTimeoutMs() },
     schema: parsedJobPostingSchema,
     schemaName: "parsed_job_posting",
@@ -234,13 +224,6 @@ async function scrapeJobPostingWithFirecrawl(url: string): Promise<ParsedJobPost
     );
   }
 
-  logParserDebug("Firecrawl scrape completed", {
-    warning: payload.data?.warning,
-    statusCode: payload.data?.metadata?.statusCode,
-    title: payload.data?.metadata?.title,
-    sourceURL: payload.data?.metadata?.sourceURL,
-  });
-
   const parsed = parsedJobPostingSchema.safeParse(payload.data?.json ?? {});
 
   if (!parsed.success) {
@@ -297,7 +280,7 @@ export async function parseJobPosting(
   await requireUserId();
 
   const value = input.value.trim();
-  const providerConfig = getAiProviderConfig();
+  const aiModel = getAiModel();
   const firecrawlConfig = getFirecrawlConfig();
   const startedAt = Date.now();
 
@@ -326,40 +309,11 @@ export async function parseJobPosting(
   }
 
   try {
-    logParserDebug("Starting parse", {
-      provider:
-        input.sourceType === "url"
-          ? "firecrawl"
-          : providerConfig?.provider ?? "unknown",
-      model: input.sourceType === "text" ? providerConfig?.model ?? "unknown" : undefined,
-      sourceType: input.sourceType,
-      timeoutMs:
-        input.sourceType === "url"
-          ? firecrawlConfig?.timeoutMs
-          : getParseTimeoutMs(),
-      url: input.sourceType === "url" ? value : undefined,
-      textLength: input.sourceType === "text" ? value.length : undefined,
-    });
-
     const parsed =
       input.sourceType === "url"
         ? await scrapeJobPostingWithFirecrawl(value)
         : await generateParsedTextPosting({ ...input, value });
     const data = normalizeParsedJobPosting(parsed, { ...input, value });
-    const durationMs = Date.now() - startedAt;
-
-    logParserDebug("Parse completed", {
-      provider:
-        input.sourceType === "url"
-          ? "firecrawl"
-          : providerConfig?.provider ?? "unknown",
-      sourceType: input.sourceType,
-      durationMs,
-      extractedFields: Object.keys(data).filter((key) => {
-        const field = data[key as keyof ParsedJobPosting];
-        return field != null && String(field).trim() !== "";
-      }),
-    });
 
     if (!hasMeaningfulParsedData(data)) {
       return {
@@ -375,11 +329,8 @@ export async function parseJobPosting(
     const durationMs = Date.now() - startedAt;
 
     console.error("Failed to parse job posting", {
-      provider:
-        input.sourceType === "url"
-          ? "firecrawl"
-          : providerConfig?.provider ?? "unknown",
-      model: input.sourceType === "text" ? providerConfig?.model ?? "unknown" : undefined,
+      provider: input.sourceType === "url" ? "firecrawl" : "ai-gateway",
+      model: input.sourceType === "text" ? aiModel ?? "unknown" : undefined,
       sourceType: input.sourceType,
       timeoutMs:
         input.sourceType === "url"

--- a/src/lib/actions/parse-job-posting.ts
+++ b/src/lib/actions/parse-job-posting.ts
@@ -2,7 +2,7 @@
 
 import { generateObject } from "ai";
 import * as z from "zod";
-import { getAiModel, isAiParsingEnabled } from "@/lib/ai";
+import { getAiModelId, isAiParsingEnabled } from "@/lib/ai";
 import { requireUserId } from "@/lib/auth-optional";
 import { getFirecrawlConfig, isFirecrawlEnabled } from "@/lib/firecrawl";
 import {
@@ -150,7 +150,7 @@ function getParseTimeoutMs() {
 }
 
 async function generateParsedTextPosting(input: Extract<ParseJobPostingInput, { sourceType: "text" }>) {
-  const model = getAiModel();
+  const model = getAiModelId();
 
   if (!model) {
     throw new Error("AI parsing is not configured.");
@@ -280,7 +280,7 @@ export async function parseJobPosting(
   await requireUserId();
 
   const value = input.value.trim();
-  const aiModel = getAiModel();
+  const aiModelId = getAiModelId();
   const firecrawlConfig = getFirecrawlConfig();
   const startedAt = Date.now();
 
@@ -330,7 +330,7 @@ export async function parseJobPosting(
 
     console.error("Failed to parse job posting", {
       provider: input.sourceType === "url" ? "firecrawl" : "ai-gateway",
-      model: input.sourceType === "text" ? aiModel ?? "unknown" : undefined,
+      model: input.sourceType === "text" ? aiModelId ?? "unknown" : undefined,
       sourceType: input.sourceType,
       timeoutMs:
         input.sourceType === "url"

--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -1,4 +1,4 @@
-export function getAiModel() {
+export function getAiModelId() {
   const model = process.env.AI_MODEL?.trim();
   const apiKey = process.env.AI_GATEWAY_API_KEY?.trim();
 
@@ -10,5 +10,5 @@ export function getAiModel() {
 }
 
 export function isAiParsingEnabled() {
-  return getAiModel() !== null;
+  return getAiModelId() !== null;
 }

--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -1,65 +1,14 @@
-import { anthropic } from "@ai-sdk/anthropic";
-import { google } from "@ai-sdk/google";
-import { openai } from "@ai-sdk/openai";
+export function getAiModel() {
+  const model = process.env.AI_MODEL?.trim();
+  const apiKey = process.env.AI_GATEWAY_API_KEY?.trim();
 
-const SUPPORTED_AI_PROVIDERS = ["anthropic", "google", "openai"] as const;
-
-type SupportedAiProvider = (typeof SUPPORTED_AI_PROVIDERS)[number];
-
-const DEFAULT_MODELS: Record<SupportedAiProvider, string> = {
-  anthropic: "claude-3-5-sonnet-latest",
-  google: "gemini-2.5-flash",
-  openai: "gpt-4.1-mini",
-};
-
-function getProviderKey(provider: SupportedAiProvider) {
-  switch (provider) {
-    case "anthropic":
-      return process.env.ANTHROPIC_API_KEY;
-    case "google":
-      return process.env.GOOGLE_GENERATIVE_AI_API_KEY;
-    case "openai":
-      return process.env.OPENAI_API_KEY;
-  }
-}
-
-export function getAiProviderConfig() {
-  const provider = process.env.AI_PROVIDER?.trim().toLowerCase();
-
-  if (!provider || !SUPPORTED_AI_PROVIDERS.includes(provider as SupportedAiProvider)) {
+  if (!model || !apiKey) {
     return null;
   }
 
-  const typedProvider = provider as SupportedAiProvider;
-  const apiKey = getProviderKey(typedProvider);
-
-  if (!apiKey) {
-    return null;
-  }
-
-  return {
-    provider: typedProvider,
-    model: process.env.AI_MODEL?.trim() || DEFAULT_MODELS[typedProvider],
-  };
+  return model;
 }
 
 export function isAiParsingEnabled() {
-  return getAiProviderConfig() !== null;
-}
-
-export function getAiLanguageModel() {
-  const config = getAiProviderConfig();
-
-  if (!config) {
-    throw new Error("AI parsing is not configured.");
-  }
-
-  switch (config.provider) {
-    case "anthropic":
-      return anthropic(config.model);
-    case "google":
-      return google(config.model);
-    case "openai":
-      return openai(config.model);
-  }
+  return getAiModel() !== null;
 }


### PR DESCRIPTION
Closes #19. Follow-up issue #51 layers Langfuse tracing on top.

## Summary

- Routes all `generateObject` calls through the Vercel AI Gateway via a single `provider/model` string
- Collapses [src/lib/ai.ts](src/lib/ai.ts) from 65 lines to 13 — one `getAiModel()` helper, no per-provider switch
- Removes hand-rolled `AI_PARSER_DEBUG` logging — Gateway dashboard replaces it
- Uninstalls `@ai-sdk/anthropic`, `@ai-sdk/google`, `@ai-sdk/openai`
- Net: **-161 lines, 3 fewer dependencies**

## ⚠️ Deployment instructions (Vercel)

This PR replaces several env vars. Update **Vercel → Project → Settings → Environment Variables** for the production environment (and any preview/development envs that had AI parsing enabled) **before merging**:

**Add:**
| Name | Value | Notes |
|---|---|---|
| `AI_GATEWAY_API_KEY` | `vck_...` | Generate from [Vercel AI Gateway dashboard](https://vercel.com/dashboard/ai-gateway) |
| `AI_MODEL` | `anthropic/claude-haiku-4.5` (or any `provider/model`) | Switch models by editing this single string |

**Remove (no longer used):**
- `AI_PROVIDER`
- `OPENAI_API_KEY`
- `ANTHROPIC_API_KEY`
- `GOOGLE_GENERATIVE_AI_API_KEY`
- `AI_PARSER_DEBUG`

**Keep as-is:**
- `AI_PARSE_TIMEOUT_MS` (still used)
- All `FIRECRAWL_*` vars (URL parsing path is unchanged)

If `AI_GATEWAY_API_KEY` and `AI_MODEL` are unset, text auto-fill is gracefully disabled — the form falls back to the no-AI render path. Firecrawl URL parsing is unaffected by this change.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — clean (Next.js 16, Turbopack)
- [x] Local end-to-end smoke test via Playwright: pasted a Senior Backend Engineer posting, every field extracted correctly (company, role, department, jobId, location, salaryMin/Max, contactName, employmentType, experienceLevel, workMode), `parseJobPosting` Server Action returned 200 in 22.6s with no errors
- [ ] After deploy: confirm a real parse appears in the Gateway dashboard at https://vercel.com/dashboard/ai-gateway with prompt/response/tokens/latency

🤖 Generated with [Claude Code](https://claude.com/claude-code)