### PR TITLE
Use the rich Markdown editor for the Job Description field

### DIFF
--- a/src/components/opportunity-form.tsx
+++ b/src/components/opportunity-form.tsx
@@ -746,8 +746,15 @@ export function OpportunityForm({
           }
           placeholder="Describe the role: responsibilities, requirements, perks. Markdown supported."
           minHeight={200}
+          onSubmit={() => {
+            if (submitDisabled || isParsing) return;
+            formRef.current?.requestSubmit();
+          }}
         />
         <input type="hidden" name="jobDescription" value={values.jobDescription} />
+        {getError("jobDescription") && (
+          <p className="text-sm text-destructive">{getError("jobDescription")}</p>
+        )}
       </div>
 
       <div className="flex gap-3">

--- a/src/components/opportunity-form.tsx
+++ b/src/components/opportunity-form.tsx
@@ -15,6 +15,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
+import { MarkdownEditor } from "@/components/markdown-editor";
 import { cn } from "@/lib/utils";
 import {
   Select,
@@ -512,7 +513,7 @@ export function OpportunityForm({
       <fieldset
         disabled={isParsing}
         aria-busy={isParsing}
-        className="m-0 space-y-6 border-0 p-0 disabled:opacity-60"
+        className="m-0 min-w-0 space-y-6 border-0 p-0 disabled:opacity-60"
       >
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
         <div className="space-y-2">
@@ -738,15 +739,15 @@ export function OpportunityForm({
 
       <div className="space-y-2">
         <Label htmlFor="jobDescription">Job Description</Label>
-        <Textarea
-          id="jobDescription"
-          name="jobDescription"
-          rows={8}
+        <MarkdownEditor
           value={values.jobDescription}
-          onChange={handleChange("jobDescription")}
-          placeholder="Paste the full job posting here (description, responsibilities, requirements)..."
-          className="resize-y"
+          onChange={(value) =>
+            setValues((prev) => ({ ...prev, jobDescription: value }))
+          }
+          placeholder="Describe the role: responsibilities, requirements, perks. Markdown supported."
+          minHeight={200}
         />
+        <input type="hidden" name="jobDescription" value={values.jobDescription} />
       </div>
 
       <div className="flex gap-3">


### PR DESCRIPTION
## Summary
- Swap the plain `<Textarea>` for the shared `MarkdownEditor` on the new/edit opportunity form, matching what's already rendered on the detail page
- Add a hidden `<input name="jobDescription">` so the controlled value submits through the Server Action even when the editor is in Preview mode (its internal textarea is unmounted there)
- Set `min-w-0` on the form fieldset so a long unbreakable string in the rendered preview can't push the form past its `max-w-2xl` cap

Closes #49.

## Test plan
- [x] New opportunity form: Job Description renders the Write/Preview tabs and toolbar (Heading, Bold, Italic, Quote, Code, Link, Bulleted/Numbered/Task list)
- [x] Type markdown (h2/h3, lists, link), submit while in Preview mode, confirm the saved record renders the markdown on the detail page
- [x] Edit page reloads the saved markdown verbatim into the editor
- [x] Cmd/Ctrl+Enter form submit still works while focus is inside the editor textarea
- [x] Pasting a very long unbreakable string and switching to Preview no longer expands the form horizontally
- [x] AI auto-fill paste box (separate textarea) is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)