### PR TITLE
Cleanup follow-ups from Cmd/Ctrl+Enter PR

### DIFF
--- a/src/components/markdown-editor.tsx
+++ b/src/components/markdown-editor.tsx
@@ -109,6 +109,7 @@ export function MarkdownEditor({
       onSubmit
     ) {
       e.preventDefault();
+      // Stop bubbling so a parent form's own Cmd+Enter handler doesn't double-submit
       e.stopPropagation();
       onSubmit();
       return;

--- a/src/lib/actions/opportunities.ts
+++ b/src/lib/actions/opportunities.ts
@@ -207,7 +207,7 @@ export async function deleteComment(commentId: string) {
 export async function createOpportunity(
   prevState: OpportunityFormState,
   formData: FormData
-): Promise<OpportunityFormState & { id?: string }> {
+): Promise<OpportunityFormState> {
   const userId = await requireUserId();
   const result = parseFormData(formData);
 


### PR DESCRIPTION
## Summary
- Drop the redundant `& { id?: string }` intersection on `createOpportunity`'s return type — `id` is already part of `OpportunityFormState` itself.
- Add a one-line comment to the `MarkdownEditor`'s Cmd+Enter `stopPropagation()` so the intent is visible at the call site. (Kept the call instead of removing it: PR #54 wired the editor into the opportunity form, which has its own Cmd+Enter listener, so suppressing the bubble is now load-bearing.)

Closes #48.

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] New opportunity form: Cmd/Ctrl+Enter inside the Job Description editor submits exactly once (no double-submit)
- [x] Comment composer: Cmd/Ctrl+Enter still saves a comment as before