### PR TITLE
Detect AI auto-fill panel by data-attribute

### DIFF
--- a/src/components/opportunity-form.tsx
+++ b/src/components/opportunity-form.tsx
@@ -371,7 +371,7 @@ export function OpportunityForm({
       const target = e.target as HTMLElement | null;
       const inAiPanel =
         target instanceof HTMLElement &&
-        (target.id === "ai-url" || target.id === "ai-text");
+        target.closest("[data-ai-panel]") !== null;
 
       if (inAiPanel) {
         if (aiEnabled && !isEditing && !autoFillDisabled) {
@@ -409,7 +409,10 @@ export function OpportunityForm({
       )}
 
       {aiEnabled && !isEditing && (
-        <div className="overflow-hidden rounded-md border border-border/70 bg-muted/40">
+        <div
+          data-ai-panel
+          className="overflow-hidden rounded-md border border-border/70 bg-muted/40"
+        >
           {urlAutofillEnabled && textAutofillEnabled && (
             <div
               role="tablist"


### PR DESCRIPTION
## Summary
- Replace the brittle id-string check in the form's Cmd/Ctrl+Enter handler with `target.closest("[data-ai-panel]")` so any element inside the AI panel routes to Auto-fill, regardless of which specific input has focus.
- Add `data-ai-panel` to the panel wrapper. Input ids (`ai-url`, `ai-text`) stay — they're still used by the `<Label htmlFor>` elements.

Pure defensive refactor — no user-visible change.

Closes #46.

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] Cmd/Ctrl+Enter in the URL input still triggers Auto-fill
- [x] Cmd/Ctrl+Enter in the Text textarea still triggers Auto-fill
- [x] Cmd/Ctrl+Enter in any regular form field still submits the form