### PR TITLE
Multi-select status filters on the opportunities page

### DIFF
--- a/src/app/(app)/opportunities/page.tsx
+++ b/src/app/(app)/opportunities/page.tsx
@@ -3,15 +3,24 @@ import { Button } from "@/components/ui/button";
 import { OpportunityTable } from "@/components/opportunity-table";
 import { StatusFilter } from "@/components/status-filter";
 import { listOpportunities, getStatusCounts } from "@/lib/actions/opportunities";
-import type { Status } from "@/lib/constants";
+import { STATUSES, type Status } from "@/lib/constants";
 
 interface PageProps {
   searchParams: Promise<{ status?: string; archived?: string; search?: string }>;
 }
 
+function parseStatusParam(raw: string | undefined): Status[] {
+  if (!raw) return [];
+  const valid = raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s): s is Status => (STATUSES as readonly string[]).includes(s));
+  return Array.from(new Set(valid));
+}
+
 export default async function OpportunitiesPage({ searchParams }: PageProps) {
   const params = await searchParams;
-  const statusFilter = (params.status as Status | "all") ?? "all";
+  const statusFilter = parseStatusParam(params.status);
   const showArchived = params.archived === "true";
   const search = params.search || undefined;
   const [opportunities, statusCounts] = await Promise.all([
@@ -38,7 +47,7 @@ export default async function OpportunitiesPage({ searchParams }: PageProps) {
       </div>
 
       {/* Filters */}
-      <StatusFilter current={statusFilter} counts={statusCounts} searchParams={params} />
+      <StatusFilter selected={statusFilter} counts={statusCounts} searchParams={params} />
 
       {/* Table */}
       <OpportunityTable opportunities={opportunities} />

--- a/src/components/status-filter.tsx
+++ b/src/components/status-filter.tsx
@@ -10,55 +10,73 @@ const filters: Array<{ value: Status | "all"; label: string }> = [
 ];
 
 interface StatusFilterProps {
-  current: string;
+  selected: Status[];
   counts: Record<string, number>;
   searchParams: Record<string, string | undefined>;
 }
 
-export function StatusFilter({ current, counts, searchParams }: StatusFilterProps) {
+export function StatusFilter({ selected, counts, searchParams }: StatusFilterProps) {
   const total = Object.values(counts).reduce((sum, n) => sum + n, 0);
   const router = useRouter();
+  const isAllActive = selected.length === 0;
 
-  function setFilter(value: string) {
+  function isActive(value: Status | "all"): boolean {
+    return value === "all" ? isAllActive : selected.includes(value);
+  }
+
+  function pushWithStatuses(next: Status[]) {
     const params = new URLSearchParams();
     for (const [key, val] of Object.entries(searchParams)) {
       if (val !== undefined && key !== "status") {
         params.set(key, val);
       }
     }
-    if (value !== "all") {
-      params.set("status", value);
+    if (next.length > 0) {
+      params.set("status", next.join(","));
     }
-    router.push(`/opportunities?${params.toString()}`);
+    const query = params.toString();
+    router.push(query ? `/opportunities?${query}` : `/opportunities`);
+  }
+
+  function onChipClick(value: Status | "all") {
+    if (value === "all") {
+      pushWithStatuses([]);
+      return;
+    }
+    const next = selected.includes(value)
+      ? selected.filter((s) => s !== value)
+      : [...selected, value];
+    pushWithStatuses(next);
   }
 
   return (
     <div className="flex items-center gap-2 overflow-x-auto">
       <div className="flex flex-nowrap gap-2">
-        {filters.map((f) => (
-          <Button
-            key={f.value}
-            variant={current === f.value ? "default" : "secondary"}
-            size="sm"
-            className={`rounded-full shrink-0 font-semibold tracking-[0.025em] ${
-              current === f.value
-                ? "shadow-md"
-                : "text-muted-foreground"
-            }`}
-            onClick={() => setFilter(f.value)}
-          >
-            {f.label}
-            <span
-              className={`ml-1 rounded-full px-1.5 py-0.5 text-xs font-medium ${
-                current === f.value
-                  ? "bg-primary-foreground/20 text-primary-foreground"
-                  : "bg-muted-foreground/10 text-muted-foreground"
+        {filters.map((f) => {
+          const active = isActive(f.value);
+          return (
+            <Button
+              key={f.value}
+              variant={active ? "default" : "secondary"}
+              size="sm"
+              className={`rounded-full shrink-0 font-semibold tracking-[0.025em] ${
+                active ? "shadow-md" : "text-muted-foreground"
               }`}
+              onClick={() => onChipClick(f.value)}
             >
-              {f.value === "all" ? total : (counts[f.value] ?? 0)}
-            </span>
-          </Button>
-        ))}
+              {f.label}
+              <span
+                className={`ml-1 rounded-full px-1.5 py-0.5 text-xs font-medium ${
+                  active
+                    ? "bg-primary-foreground/20 text-primary-foreground"
+                    : "bg-muted-foreground/10 text-muted-foreground"
+                }`}
+              >
+                {f.value === "all" ? total : (counts[f.value] ?? 0)}
+              </span>
+            </Button>
+          );
+        })}
       </div>
     </div>
   );

--- a/src/lib/actions/opportunities.ts
+++ b/src/lib/actions/opportunities.ts
@@ -2,7 +2,7 @@
 
 import { db } from "@/lib/db";
 import { opportunities, statusHistory, opportunityComments } from "@/lib/db/schema";
-import { eq, asc, desc, and, sql } from "drizzle-orm";
+import { eq, asc, desc, and, sql, inArray } from "drizzle-orm";
 import { nanoid } from "nanoid";
 import { revalidatePath } from "next/cache";
 import type { Status } from "@/lib/constants";
@@ -74,7 +74,7 @@ export async function getStatusCounts(
 }
 
 export async function listOpportunities(
-  statusFilter?: Status | "all",
+  statusFilter?: Status[],
   showArchived = false,
   search?: string
 ) {
@@ -84,8 +84,8 @@ export async function listOpportunities(
     eq(opportunities.archived, showArchived ? 1 : 0),
   ];
 
-  if (statusFilter && statusFilter !== "all") {
-    conditions.push(eq(opportunities.status, statusFilter));
+  if (statusFilter && statusFilter.length > 0) {
+    conditions.push(inArray(opportunities.status, statusFilter));
   }
 
   if (search) {


### PR DESCRIPTION
## Summary
- Status chips now toggle independently with OR semantics — any combination of Saved/Applied/Interviewing/etc. shows rows whose status matches any selected one.
- "All" remains a one-click reset that clears every other selection. Toggling off the last specific chip auto-routes back to "All" so the filter never lands in an empty-selection dead-end.
- Selected statuses round-trip through the URL as a comma-separated list (\`?status=saved,applied\`), preserving \`search\` and \`archived\` params alongside.
- Defensive parsing: split, trim, dedupe, and filter against the \`STATUSES\` allowlist. Typo'd values are silently dropped (e.g. \`?status=savd,applied\` → "Applied" only). A fully invalid or empty param falls back to "All".
- Server-side query swaps \`eq()\` for \`inArray()\` in \`listOpportunities\`, gated on a non-empty array.

\`getStatusCounts\` is unchanged — per-chip counts continue to reflect the universe of that status (within current archived/search filters), not the current selection. This matches the existing behavior and avoids badges that flicker as you click.

Closes #45.

## Implementation Notes
- **Out of scope** (not changed in this PR): chips for \`workMode\`, \`employmentType\`, \`experienceLevel\`, or \`archived\`. Sort changes are tracked separately in #6.
- **Backwards compatible**: existing single-status URLs like \`?status=saved\` work unchanged — \`"saved".split(",")\` round-trips correctly.
- **Behavior change worth flagging**: a typo'd URL like \`?status=savd\` previously showed zero rows; under this PR it falls back to "All" and shows everything. Per the issue spec ("filter unknowns silently"), but worth noting for shared links.

## Test plan
- [x] Production build passes (\`npm run build\`)
- [x] \`npx tsc --noEmit\` passes
- [x] **Single chip select** — clicking "Applied" sets \`?status=applied\`, table shows 10 Applied rows, only Applied chip is styled active
- [x] **Multi-select toggle on** — clicking "Interviewing" with Applied selected sets \`?status=applied,interviewing\` (URL-encoded comma), both chips visually active, table shows 17 mixed rows
- [x] **Toggle off (intermediate)** — clicking Applied again drops it: URL becomes \`?status=interviewing\`, only 7 rows
- [x] **Empty-selection snap-back** — toggling off the last specific chip routes to \`/opportunities\` (no \`status\` param), All becomes active
- [x] **Typo'd URL** — \`?status=savd,applied\` filters to Applied only and ignores \`savd\`
- [x] **Search + status preservation** — clicking a chip with \`search=engineer\` in URL preserves the search param