### PR TITLE
Add dark mode with light/dark/system toggle

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "nanoid": "^5.1.7",
         "next": "16.2.2",
         "next-auth": "^5.0.0-beta.30",
+        "next-themes": "^0.4.6",
         "react": "19.2.4",
         "react-dom": "19.2.4",
         "react-markdown": "^10.1.0",
@@ -10466,6 +10467,16 @@
         "nodemailer": {
           "optional": true
         }
+      }
+    },
+    "node_modules/next-themes": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",
+      "integrity": "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
       }
     },
     "node_modules/next/node_modules/nanoid": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "nanoid": "^5.1.7",
     "next": "16.2.2",
     "next-auth": "^5.0.0-beta.30",
+    "next-themes": "^0.4.6",
     "react": "19.2.4",
     "react-dom": "19.2.4",
     "react-markdown": "^10.1.0",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -106,6 +106,14 @@
   --status-error-fg: #B91C1C;
   --status-violet-bg: #EDE9FE;
   --status-violet-fg: #6D28D9;
+  /* Status dots */
+  --status-dot-saved: #9CA3AF;
+  --status-dot-applied: #3B82F6;
+  --status-dot-interviewing: #F59E0B;
+  --status-dot-offered: #8B5CF6;
+  --status-dot-rejected: #EF4444;
+  --status-dot-withdrawn: #64748B;
+  --status-dot-accepted: #10B981;
 }
 
 .dark {
@@ -162,6 +170,14 @@
   --status-error-fg: #fca5a5;
   --status-violet-bg: #4c1d9533;
   --status-violet-fg: #c4b5fd;
+  /* Status dots — brightened for visibility on dark surfaces */
+  --status-dot-saved: #c2c6d6;
+  --status-dot-applied: #60a5fa;
+  --status-dot-interviewing: #fbbf24;
+  --status-dot-offered: #a78bfa;
+  --status-dot-rejected: #f87171;
+  --status-dot-withdrawn: #94a3b8;
+  --status-dot-accepted: #34d399;
 }
 
 @layer base {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -93,40 +93,75 @@
   --sidebar-accent-foreground: #1A56DB;
   --sidebar-border: #E5E7EB;
   --sidebar-ring: #1A56DB;
+  /* Status badges */
+  --status-neutral-bg: #F3F4F6;
+  --status-neutral-fg: #6B7280;
+  --status-info-bg: #DBEAFE;
+  --status-info-fg: #2563EB;
+  --status-warning-bg: #FEF3C7;
+  --status-warning-fg: #B45309;
+  --status-success-bg: #D1FAE5;
+  --status-success-fg: #047857;
+  --status-error-bg: #FEE2E2;
+  --status-error-fg: #B91C1C;
+  --status-violet-bg: #EDE9FE;
+  --status-violet-fg: #6D28D9;
 }
 
 .dark {
-  --background: oklch(0.145 0 0);
-  --foreground: oklch(0.985 0 0);
-  --card: oklch(0.205 0 0);
-  --card-foreground: oklch(0.985 0 0);
-  --popover: oklch(0.205 0 0);
-  --popover-foreground: oklch(0.985 0 0);
-  --primary: oklch(0.922 0 0);
-  --primary-foreground: oklch(0.205 0 0);
-  --secondary: oklch(0.269 0 0);
-  --secondary-foreground: oklch(0.985 0 0);
-  --muted: oklch(0.269 0 0);
-  --muted-foreground: oklch(0.708 0 0);
-  --accent: oklch(0.269 0 0);
-  --accent-foreground: oklch(0.985 0 0);
-  --destructive: oklch(0.704 0.191 22.216);
-  --border: oklch(1 0 0 / 10%);
-  --input: oklch(1 0 0 / 15%);
-  --ring: oklch(0.556 0 0);
-  --chart-1: oklch(0.87 0 0);
-  --chart-2: oklch(0.556 0 0);
-  --chart-3: oklch(0.439 0 0);
-  --chart-4: oklch(0.371 0 0);
-  --chart-5: oklch(0.269 0 0);
-  --sidebar: oklch(0.205 0 0);
-  --sidebar-foreground: oklch(0.985 0 0);
-  --sidebar-primary: oklch(0.488 0.243 264.376);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.269 0 0);
-  --sidebar-accent-foreground: oklch(0.985 0 0);
-  --sidebar-border: oklch(1 0 0 / 10%);
-  --sidebar-ring: oklch(0.556 0 0);
+  /* Surface / Background */
+  --background: #10131a;
+  --foreground: #e1e2ec;
+  --card: #1d2027;
+  --card-foreground: #e1e2ec;
+  --popover: #272a31;
+  --popover-foreground: #e1e2ec;
+  /* Primary (Brand) — primary-container from spec, keeps continuity with light #1A56DB */
+  --primary: #4d8eff;
+  --primary-foreground: #ffffff;
+  /* Secondary */
+  --secondary: #272a31;
+  --secondary-foreground: #e1e2ec;
+  /* Muted / Placeholder */
+  --muted: #1d2027;
+  --muted-foreground: #c2c6d6;
+  /* Accent */
+  --accent: #272a31;
+  --accent-foreground: #e1e2ec;
+  /* Destructive (Error/Rejected) */
+  --destructive: #ffb4ab;
+  /* Borders & Dividers */
+  --border: #424754;
+  --input: #424754;
+  --ring: #4d8eff;
+  /* Charts — light-theme hues brightened ~15% for dark surfaces */
+  --chart-1: #4d8eff;
+  --chart-2: #34d399;
+  --chart-3: #fbbf24;
+  --chart-4: #f87171;
+  --chart-5: #9ca3af;
+  /* Sidebar */
+  --sidebar: #191b23;
+  --sidebar-foreground: #c2c6d6;
+  --sidebar-primary: #4d8eff;
+  --sidebar-primary-foreground: #ffffff;
+  --sidebar-accent: #272a31;
+  --sidebar-accent-foreground: #e1e2ec;
+  --sidebar-border: #424754;
+  --sidebar-ring: #4d8eff;
+  /* Status badges — low-saturation backgrounds with bright foregrounds */
+  --status-neutral-bg: #272a31;
+  --status-neutral-fg: #c2c6d6;
+  --status-info-bg: #1e3a8a33;
+  --status-info-fg: #93c5fd;
+  --status-warning-bg: #78350f33;
+  --status-warning-fg: #fcd34d;
+  --status-success-bg: #064e3b33;
+  --status-success-fg: #6ee7b7;
+  --status-error-bg: #7f1d1d33;
+  --status-error-fg: #fca5a5;
+  --status-violet-bg: #4c1d9533;
+  --status-violet-fg: #c4b5fd;
 }
 
 @layer base {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Manrope, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import { ThemeProvider } from "@/components/theme-provider";
 
 const manrope = Manrope({
   variable: "--font-sans",
@@ -26,8 +27,18 @@ export default function RootLayout({
     <html
       lang="en"
       className={`${manrope.variable} ${geistMono.variable} h-full antialiased`}
+      suppressHydrationWarning
     >
-      <body className="h-full overflow-hidden">{children}</body>
+      <body className="h-full overflow-hidden">
+        <ThemeProvider
+          attribute="class"
+          defaultTheme="system"
+          enableSystem
+          disableTransitionOnChange
+        >
+          {children}
+        </ThemeProvider>
+      </body>
     </html>
   );
 }

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -15,6 +15,7 @@ import {
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { signOutAction } from "@/lib/actions/auth";
+import { ThemeToggle } from "@/components/layout/theme-toggle";
 
 const navItems = [
   { href: "/dashboard", label: "Dashboard", icon: LayoutDashboard },
@@ -155,6 +156,8 @@ export function Sidebar({
             </button>
           </form>
         )}
+
+        <ThemeToggle collapsed={collapsed} />
 
         {/* Collapse toggle (desktop only) */}
         <button

--- a/src/components/layout/theme-toggle.tsx
+++ b/src/components/layout/theme-toggle.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { useTheme } from "next-themes";
+import { Sun, Moon, Monitor, Palette } from "lucide-react";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { cn } from "@/lib/utils";
+
+interface ThemeToggleProps {
+  collapsed: boolean;
+}
+
+export function ThemeToggle({ collapsed }: ThemeToggleProps) {
+  const { setTheme } = useTheme();
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger
+        title={collapsed ? "Theme" : undefined}
+        aria-label="Toggle theme"
+        className={cn(
+          "flex w-full items-center gap-3 rounded-lg px-3 py-2 text-[0.8125rem] font-semibold tracking-[0.025em] text-sidebar-foreground transition-colors hover:bg-sidebar-accent/50 hover:text-sidebar-accent-foreground",
+          collapsed && "justify-center px-2"
+        )}
+      >
+        <Palette className="size-5 shrink-0" />
+        {!collapsed && <span>Theme</span>}
+      </DropdownMenuTrigger>
+      <DropdownMenuContent side="top" align="start" className="min-w-[8rem]">
+        <DropdownMenuItem onClick={() => setTheme("light")}>
+          <Sun className="size-4" />
+          Light
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={() => setTheme("dark")}>
+          <Moon className="size-4" />
+          Dark
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={() => setTheme("system")}>
+          <Monitor className="size-4" />
+          System
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/src/components/layout/theme-toggle.tsx
+++ b/src/components/layout/theme-toggle.tsx
@@ -32,15 +32,15 @@ export function ThemeToggle({ collapsed }: ThemeToggleProps) {
       </DropdownMenuTrigger>
       <DropdownMenuContent side="top" align="start" className="min-w-[8rem]">
         <DropdownMenuItem onClick={() => setTheme("light")}>
-          <Sun className="size-4" />
+          <Sun />
           Light
         </DropdownMenuItem>
         <DropdownMenuItem onClick={() => setTheme("dark")}>
-          <Moon className="size-4" />
+          <Moon />
           Dark
         </DropdownMenuItem>
         <DropdownMenuItem onClick={() => setTheme("system")}>
-          <Monitor className="size-4" />
+          <Monitor />
           System
         </DropdownMenuItem>
       </DropdownMenuContent>

--- a/src/components/opportunity-form.tsx
+++ b/src/components/opportunity-form.tsx
@@ -486,7 +486,7 @@ export function OpportunityForm({
           </div>
 
           {aiSuccess && !aiError && (
-            <p className="rounded-md bg-emerald-100 p-3 text-sm text-emerald-900">
+            <p className="rounded-md bg-[var(--status-success-bg)] p-3 text-sm text-[var(--status-success-fg)]">
               {aiSuccess}
             </p>
           )}

--- a/src/components/opportunity-table.tsx
+++ b/src/components/opportunity-table.tsx
@@ -117,7 +117,7 @@ export function OpportunityTable({ opportunities }: OpportunityTableProps) {
       </div>
 
       {/* Desktop: Table */}
-      <div className="hidden md:block bg-card border rounded-lg">
+      <div className="hidden md:block bg-card border rounded-lg overflow-hidden">
         <Table>
           <TableHeader className="bg-background">
             <TableRow className="hover:bg-transparent border-b border-border">

--- a/src/components/opportunity-timeline.tsx
+++ b/src/components/opportunity-timeline.tsx
@@ -96,7 +96,7 @@ function StatusEvent({
   note: string | null;
 }) {
   const label = STATUS_LABELS[status as Status] ?? status;
-  const dotColor = STATUS_DOT_COLORS[status as Status] ?? "bg-gray-400";
+  const dotColor = STATUS_DOT_COLORS[status as Status] ?? "bg-muted-foreground";
 
   return (
     <li className="relative pl-8">

--- a/src/components/theme-provider.tsx
+++ b/src/components/theme-provider.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+import { ThemeProvider as NextThemesProvider } from "next-themes";
+import type { ComponentProps } from "react";
+
+export function ThemeProvider({
+  children,
+  ...props
+}: ComponentProps<typeof NextThemesProvider>) {
+  return <NextThemesProvider {...props}>{children}</NextThemesProvider>;
+}

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -31,13 +31,13 @@ export const STATUS_COLORS: Record<Status, string> = {
 };
 
 export const STATUS_DOT_COLORS: Record<Status, string> = {
-  saved: "bg-[#9CA3AF]",
-  applied: "bg-[#3B82F6]",
-  interviewing: "bg-[#F59E0B]",
-  offered: "bg-[#8B5CF6]",
-  rejected: "bg-[#EF4444]",
-  withdrawn: "bg-[#64748B]",
-  accepted: "bg-[#10B981]",
+  saved: "bg-[var(--status-dot-saved)]",
+  applied: "bg-[var(--status-dot-applied)]",
+  interviewing: "bg-[var(--status-dot-interviewing)]",
+  offered: "bg-[var(--status-dot-offered)]",
+  rejected: "bg-[var(--status-dot-rejected)]",
+  withdrawn: "bg-[var(--status-dot-withdrawn)]",
+  accepted: "bg-[var(--status-dot-accepted)]",
 };
 
 export const WORK_MODES = ["remote", "hybrid", "onsite"] as const;

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -21,13 +21,13 @@ export const STATUS_LABELS: Record<Status, string> = {
 };
 
 export const STATUS_COLORS: Record<Status, string> = {
-  saved: "bg-[#F3F4F6] text-[#6B7280]",
-  applied: "bg-[#F3F4F6] text-[#6B7280]",
-  interviewing: "bg-[#FEF3C7] text-[#F59E0B]",
-  offered: "bg-[#D1FAE5] text-[#10B981]",
-  rejected: "bg-[#FEE2E2] text-[#EF4444]",
-  withdrawn: "bg-[#FEF3C7] text-[#D97706]",
-  accepted: "bg-[#D1FAE5] text-[#059669]",
+  saved: "bg-[var(--status-neutral-bg)] text-[var(--status-neutral-fg)]",
+  applied: "bg-[var(--status-neutral-bg)] text-[var(--status-neutral-fg)]",
+  interviewing: "bg-[var(--status-warning-bg)] text-[var(--status-warning-fg)]",
+  offered: "bg-[var(--status-success-bg)] text-[var(--status-success-fg)]",
+  rejected: "bg-[var(--status-error-bg)] text-[var(--status-error-fg)]",
+  withdrawn: "bg-[var(--status-warning-bg)] text-[var(--status-warning-fg)]",
+  accepted: "bg-[var(--status-success-bg)] text-[var(--status-success-fg)]",
 };
 
 export const STATUS_DOT_COLORS: Record<Status, string> = {


### PR DESCRIPTION
## Summary

Closes #14.

- Wires up `next-themes` with light / dark / system options; `defaultTheme="system"` so first-time visitors follow their OS preference and explicit choices persist via localStorage
- Adds a Stitch-derived dark palette to `globals.css`, keeping brand continuity by using `#4d8eff` (Stitch `primary-container`) for primary instead of the pastel default — that's closer to the existing light-mode `#1A56DB`
- Introduces semantic `--status-*-bg/fg` tokens so status badges, the AI success toast, and the timeline fallback respond to the active theme instead of using hardcoded hex pairs
- Adds a sidebar toggle between the existing logout and collapse controls; the dropdown shows Light / Dark / System rather than cycling on click

## Test plan

- [ ] First-time visit (clear `localStorage`) follows OS preference on `/`, `/login`, and `/opportunities`
- [ ] Toggle Light → app switches to light, persists across reload, persists after navigating to `/login` (auth enabled) and back
- [ ] Toggle Dark → same checks
- [ ] Toggle System → reverts to OS preference and tracks OS changes
- [ ] Status badges (Saved / Applied / Interviewing / Offered / Rejected / Withdrawn / Accepted) are legible in both modes on the opportunities list and detail page
- [ ] AI auto-fill success toast on the new opportunity form is legible in both modes
- [ ] No hydration warnings in the console after `next-themes` mounts
- [ ] Google "Continue with Google" icon keeps its brand colors in both modes (must not be themed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)