### PR TITLE
Hotfix: reorder sidebar bottom nav to put Logout last

### DIFF
--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -141,22 +141,6 @@ export function Sidebar({
             onClick={onMobileClose}
           />
         ))}
-        {authEnabled && (
-          <form action={signOutAction}>
-            <button
-              type="submit"
-              title={collapsed ? "Logout" : undefined}
-              className={cn(
-                "flex w-full items-center gap-3 rounded-lg px-3 py-2 text-[0.8125rem] font-semibold tracking-[0.025em] text-sidebar-foreground transition-colors hover:bg-sidebar-accent/50 hover:text-sidebar-accent-foreground",
-                collapsed && "justify-center px-2"
-              )}
-            >
-              <LogOut className="size-5 shrink-0" />
-              {!collapsed && <span>Logout</span>}
-            </button>
-          </form>
-        )}
-
         <ThemeToggle collapsed={collapsed} />
 
         {/* Collapse toggle (desktop only) */}
@@ -174,6 +158,22 @@ export function Sidebar({
             </>
           )}
         </button>
+
+        {authEnabled && (
+          <form action={signOutAction}>
+            <button
+              type="submit"
+              title={collapsed ? "Logout" : undefined}
+              className={cn(
+                "flex w-full items-center gap-3 rounded-lg px-3 py-2 text-[0.8125rem] font-semibold tracking-[0.025em] text-sidebar-foreground transition-colors hover:bg-sidebar-accent/50 hover:text-sidebar-accent-foreground",
+                collapsed && "justify-center px-2"
+              )}
+            >
+              <LogOut className="size-5 shrink-0" />
+              {!collapsed && <span>Logout</span>}
+            </button>
+          </form>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

Reorders the sidebar bottom nav from **Settings → Logout → Theme → Collapse** to **Settings → Theme → Collapse → Logout**. Logout was sandwiched between Settings and Theme, which read awkwardly. Account actions belong at the very bottom; navigation, preferences, and UI chrome sit above them.

## Test plan

- [ ] Sidebar bottom nav order is Settings → Theme → Collapse → Logout (auth enabled)
- [ ] With `AUTH_DISABLED=true`, Logout is hidden and order is Settings → Theme → Collapse
- [ ] Tab order matches visual order

🤖 Generated with [Claude Code](https://claude.com/claude-code)