### PR TITLE
Bump opportunity updatedAt on comment add/edit/delete

### DIFF
--- a/src/lib/actions/opportunities.ts
+++ b/src/lib/actions/opportunities.ts
@@ -151,6 +151,12 @@ export async function addComment(opportunityId: string, body: string) {
     updatedAt: now,
   });
 
+  await db
+    .update(opportunities)
+    .set({ updatedAt: now })
+    .where(and(eq(opportunities.id, opportunityId), eq(opportunities.userId, userId)));
+
+  revalidatePath("/opportunities");
   revalidatePath(`/opportunities/${opportunityId}`);
 }
 
@@ -185,11 +191,18 @@ export async function updateComment(commentId: string, body: string) {
     throw new Error("Comment cannot be empty");
   }
 
+  const now = new Date().toISOString();
   await db
     .update(opportunityComments)
-    .set({ body: trimmed, updatedAt: new Date().toISOString() })
+    .set({ body: trimmed, updatedAt: now })
     .where(eq(opportunityComments.id, commentId));
 
+  await db
+    .update(opportunities)
+    .set({ updatedAt: now })
+    .where(and(eq(opportunities.id, opportunityId), eq(opportunities.userId, userId)));
+
+  revalidatePath("/opportunities");
   revalidatePath(`/opportunities/${opportunityId}`);
 }
 
@@ -201,6 +214,12 @@ export async function deleteComment(commentId: string) {
     .delete(opportunityComments)
     .where(eq(opportunityComments.id, commentId));
 
+  await db
+    .update(opportunities)
+    .set({ updatedAt: new Date().toISOString() })
+    .where(and(eq(opportunities.id, opportunityId), eq(opportunities.userId, userId)));
+
+  revalidatePath("/opportunities");
   revalidatePath(`/opportunities/${opportunityId}`);
 }
 


### PR DESCRIPTION
## Summary

- The opportunities list "Last Contact" column is derived from `opportunities.updatedAt`, but commenting actions only touched the `opportunity_comments` row, so adding/editing/deleting a comment never moved the column.
- All three comment actions also only revalidated the detail page, not `/opportunities`, so even after fixing the timestamp the list view would stay stale until the next full request.
- `addComment`, `updateComment`, and `deleteComment` in `src/lib/actions/opportunities.ts` now bump the parent opportunity's `updatedAt` (scoped by `userId`, matching the existing ownership pattern) and revalidate both paths — same shape as `updateOpportunityStatus`.

Fixes #63

## Test plan
- [x] Add a comment → row's "Last Contact" on `/opportunities` jumps to "Today" (verified end-to-end via Playwright; jumped from "3 weeks ago" to "Today").
- [x] Edit a comment → `opportunities.updated_at` advances in the DB (verified via direct sqlite read).
- [x] Delete a comment → `opportunities.updated_at` advances in the DB (verified via direct sqlite read).
- [x] Existing flows (status change, opportunity edit) still bump `updatedAt` as before — no regressions in the unchanged actions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)