### PR TITLE
Rebrand product from "Opportunity Tracker" to "NextOpp"

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,7 +19,7 @@ AUTH_LINKEDIN_SECRET=
 
 # Email magic link (passwordless) — https://resend.com
 AUTH_RESEND_KEY=
-AUTH_EMAIL_FROM= # e.g., "Opportunity Tracker <noreply@yourdomain.com>"
+AUTH_EMAIL_FROM= # e.g., "NextOpp <noreply@yourdomain.com>"
 
 # Comma-separated list of GitHub usernames or email addresses allowed to sign in (leave empty to allow all)
 ALLOWED_USERS=

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 @AGENTS.md
 
-# Opportunity Tracker
+# NextOpp
 
 Job opportunity tracking web app. Open source, single-user (multi-user planned — see issue #1).
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Opportunity Tracker
+# NextOpp
 
 A simple web app to track job opportunities during your search. Keep tabs on where you've applied, interview status, salary ranges, notes, and more — all in one place.
 
@@ -110,7 +110,7 @@ Passwordless sign-in via email using [Resend](https://resend.com).
 
 ```bash
 AUTH_RESEND_KEY=your-api-key
-AUTH_EMAIL_FROM="Opportunity Tracker <noreply@yourdomain.com>"  # optional, defaults to noreply@resend.dev
+AUTH_EMAIL_FROM="NextOpp <noreply@yourdomain.com>"  # optional, defaults to noreply@resend.dev
 ```
 
 ### Restricting Access

--- a/src/app/(marketing)/layout.tsx
+++ b/src/app/(marketing)/layout.tsx
@@ -16,7 +16,7 @@ export default function MarketingLayout({
             className="flex items-center gap-2 text-sm font-semibold sm:text-base"
           >
             <Briefcase className="size-5 shrink-0 text-primary sm:size-6" />
-            <span>Opportunity Tracker</span>
+            <span>NextOpp</span>
           </Link>
           <SignInButton />
         </div>
@@ -26,7 +26,7 @@ export default function MarketingLayout({
 
       <footer className="border-t border-border">
         <div className="mx-auto flex w-full max-w-6xl flex-col items-center justify-between gap-3 px-4 py-6 text-sm text-muted-foreground sm:flex-row sm:px-6 lg:px-8">
-          <span>Opportunity Tracker — open source</span>
+          <span>NextOpp — open source</span>
           <a
             href="https://github.com/zachradtka/opportunity-tracker"
             target="_blank"

--- a/src/app/(marketing)/login/page.tsx
+++ b/src/app/(marketing)/login/page.tsx
@@ -13,8 +13,8 @@ import { GitHubIcon, GoogleIcon, LinkedInIcon } from "./provider-icons";
 import { EmailSubmitButton } from "./email-submit-button";
 
 export const metadata: Metadata = {
-  title: "Sign in — Opportunity Tracker",
-  description: "Sign in to your Opportunity Tracker account",
+  title: "Sign in — NextOpp",
+  description: "Sign in to your NextOpp account",
 };
 
 const errorMessages: Record<string, string> = {
@@ -107,7 +107,7 @@ function SignInForms({
     <>
       <div className="mb-6 text-center">
         <h1 className="text-xl font-semibold sm:text-2xl">
-          Sign in to Opportunity Tracker
+          Sign in to NextOpp
         </h1>
         <p className="mt-2 text-sm text-muted-foreground">
           Continue to your interview pipeline

--- a/src/app/(marketing)/page.tsx
+++ b/src/app/(marketing)/page.tsx
@@ -6,7 +6,7 @@ import { getOptionalSession, isAuthEnabled } from "@/lib/auth-optional";
 import { Button } from "@/components/ui/button";
 
 export const metadata: Metadata = {
-  title: "Opportunity Tracker — track your interviewing journey",
+  title: "NextOpp — track your interviewing journey",
   description:
     "A central place to track job applications, manage your interview pipeline, and log every update along the way.",
 };

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -14,7 +14,7 @@ const geistMono = Geist_Mono({
 });
 
 export const metadata: Metadata = {
-  title: "Opportunity Tracker",
+  title: "NextOpp",
   description: "Track your job search opportunities",
 };
 

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -103,7 +103,7 @@ export function Sidebar({
           {!collapsed && (
             <div className="flex flex-col">
               <span className="text-sm font-semibold leading-tight">
-                Opportunity Tracker
+                NextOpp
               </span>
             </div>
           )}

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -37,7 +37,7 @@ function buildProviders() {
     providers.push(
       Resend({
         apiKey: process.env.AUTH_RESEND_KEY,
-        from: process.env.AUTH_EMAIL_FROM ?? "Opportunity Tracker <noreply@resend.dev>",
+        from: process.env.AUTH_EMAIL_FROM ?? "NextOpp <noreply@resend.dev>",
       })
     );
   }


### PR DESCRIPTION
## Summary
- Update all in-product references (root + marketing + login + sidebar metadata, default Resend `from`, README/CLAUDE.md headings, `.env.example` example) from "Opportunity Tracker" to "NextOpp"
- Repo URL, `package.json` name, `cd` clone instruction, and Turso db examples remain on the old name — those are deferred to #60 (domain + repo rename)
- Verification: `grep -rin "opportunity tracker" --include="*.ts" --include="*.tsx" --include="*.md" --include="*.example"` returns zero matches

Closes #59.

## Test plan
- [x] `npm run dev` and confirm browser tab title reads "NextOpp"
- [x] Marketing landing page header + footer show "NextOpp"
- [x] `/login` heading reads "Sign in to NextOpp"
- [x] Sidebar brand label reads "NextOpp"
- [x] `npm run build` succeeds