### PR TITLE
Fix race in ensureLocalUser when AUTH_DISABLED=true

### DIFF
--- a/src/lib/auth-optional.ts
+++ b/src/lib/auth-optional.ts
@@ -1,27 +1,21 @@
 import { auth } from "./auth";
 import { db } from "./db";
 import { users } from "./db/schema";
-import { eq } from "drizzle-orm";
 
 const LOCAL_USER_ID = "local-dev-user";
 
 async function ensureLocalUser() {
-  const existing = await db
-    .select()
-    .from(users)
-    .where(eq(users.id, LOCAL_USER_ID))
-    .limit(1);
-
-  if (existing.length === 0) {
-    const now = new Date().toISOString();
-    await db.insert(users).values({
+  const now = new Date().toISOString();
+  await db
+    .insert(users)
+    .values({
       id: LOCAL_USER_ID,
       name: "Local User",
       email: "local@localhost",
       createdAt: now,
       updatedAt: now,
-    });
-  }
+    })
+    .onConflictDoNothing();
 }
 
 export async function getOptionalSession() {


### PR DESCRIPTION
## Summary
- `ensureLocalUser` did a check-then-insert (`SELECT WHERE id=...` then `INSERT`) which is not safe under concurrent callers.
- The build-time prerender of `/opportunities` calls `listOpportunities` and `getStatusCounts` via `Promise.all`. With `AUTH_DISABLED=true` (preview env), both call `requireUserId` → `ensureLocalUser` in parallel against an empty `users` table. Both pass the existence check, both attempt `INSERT`, and the second one hits `UNIQUE constraint failed: users.email`.
- Replace check-then-insert with a single `INSERT ... ON CONFLICT DO NOTHING` so the operation is idempotent.

This was discovered when the preview deploy for #66 (rebrand) failed against a freshly-provisioned preview Turso database.

## Test plan
- [x] `npm run build` succeeds locally with `AUTH_DISABLED=true` against an empty Turso db
- [x] Visit `/opportunities` after the build — local user is created, page renders
- [x] Re-run with the local user already present — no error, no duplicate row