### PR TITLE
Bulk archive on Active list (desktop)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "remark-gfm": "^4.0.1",
         "resend": "^6.12.0",
         "shadcn": "^4.1.2",
+        "sonner": "^2.0.7",
         "tailwind-merge": "^3.5.0",
         "tw-animate-css": "^1.4.0",
         "zod": "^4.3.6"
@@ -12556,6 +12557,16 @@
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
       "license": "MIT"
+    },
+    "node_modules/sonner": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.7.tgz",
+      "integrity": "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      }
     },
     "node_modules/source-map": {
       "version": "0.6.1",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "remark-gfm": "^4.0.1",
     "resend": "^6.12.0",
     "shadcn": "^4.1.2",
+    "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0",
     "tw-animate-css": "^1.4.0",
     "zod": "^4.3.6"

--- a/src/app/(app)/opportunities/page.tsx
+++ b/src/app/(app)/opportunities/page.tsx
@@ -50,7 +50,10 @@ export default async function OpportunitiesPage({ searchParams }: PageProps) {
       <StatusFilter selected={statusFilter} counts={statusCounts} searchParams={params} />
 
       {/* Table */}
-      <OpportunityTable opportunities={opportunities} />
+      <OpportunityTable
+        opportunities={opportunities}
+        view={showArchived ? "archive" : "active"}
+      />
     </div>
   );
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Manrope, Geist_Mono } from "next/font/google";
+import { Toaster } from "sonner";
 import "./globals.css";
 import { ThemeProvider } from "@/components/theme-provider";
 
@@ -37,6 +38,7 @@ export default function RootLayout({
           disableTransitionOnChange
         >
           {children}
+          <Toaster richColors closeButton />
         </ThemeProvider>
       </body>
     </html>

--- a/src/components/opportunity-table.tsx
+++ b/src/components/opportunity-table.tsx
@@ -299,7 +299,7 @@ export function OpportunityTable({
                     />
                   </TableHead>
                 )}
-                <TableHead className="w-full">Company &amp; Role</TableHead>
+                <TableHead className="w-full pl-4">Company &amp; Role</TableHead>
                 <TableHead className="min-w-[200px]">Status</TableHead>
                 <TableHead className="min-w-[180px]">Applied Date</TableHead>
                 <TableHead className="min-w-[180px]">Last Contact</TableHead>
@@ -333,7 +333,7 @@ export function OpportunityTable({
                       />
                     </TableCell>
                   )}
-                  <TableCell className="w-full py-4">
+                  <TableCell className="w-full py-4 pl-4">
                     <Link
                       href={`/opportunities/${opp.id}`}
                       className="hover:underline"

--- a/src/components/opportunity-table.tsx
+++ b/src/components/opportunity-table.tsx
@@ -333,7 +333,7 @@ export function OpportunityTable({
                       />
                     </TableCell>
                   )}
-                  <TableCell className="py-4">
+                  <TableCell className="w-full py-4">
                     <Link
                       href={`/opportunities/${opp.id}`}
                       className="hover:underline"
@@ -346,16 +346,16 @@ export function OpportunityTable({
                       </div>
                     </Link>
                   </TableCell>
-                  <TableCell>
+                  <TableCell className="min-w-[200px]">
                     <StatusBadge
                       status={opp.status as Status}
                       opportunityId={opp.id}
                     />
                   </TableCell>
-                  <TableCell className="text-sm font-medium text-muted-foreground">
+                  <TableCell className="min-w-[180px] text-sm font-medium text-muted-foreground">
                     {formatDate(opp.appliedAt)}
                   </TableCell>
-                  <TableCell className="text-sm font-medium text-muted-foreground">
+                  <TableCell className="min-w-[180px] text-sm font-medium text-muted-foreground">
                     {formatRelativeDate(opp.updatedAt)}
                   </TableCell>
                 </TableRow>

--- a/src/components/opportunity-table.tsx
+++ b/src/components/opportunity-table.tsx
@@ -1,7 +1,12 @@
 "use client";
 
+import { useEffect, useRef, useState, useTransition } from "react";
+import { useSearchParams } from "next/navigation";
 import Link from "next/link";
-import { Calendar } from "lucide-react";
+import { Archive, Calendar, X } from "lucide-react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
 import {
   Table,
   TableBody,
@@ -11,11 +16,13 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { StatusBadge } from "@/components/status-badge";
+import { bulkArchive } from "@/lib/actions/opportunities";
 import type { Opportunity } from "@/lib/db/schema";
 import type { Status } from "@/lib/constants";
 
 interface OpportunityTableProps {
   opportunities: Opportunity[];
+  view: "active" | "archive";
 }
 
 function formatDate(dateStr: string | null): string {
@@ -93,7 +100,119 @@ function MobileCard({ opp }: { opp: Opportunity }) {
   );
 }
 
-export function OpportunityTable({ opportunities }: OpportunityTableProps) {
+function formatArchiveCounts(updated: number, unchanged: number): string {
+  const parts: string[] = [];
+  if (updated > 0) {
+    parts.push(
+      `Archived ${updated} ${updated === 1 ? "opportunity" : "opportunities"}`,
+    );
+  }
+  if (unchanged > 0) {
+    parts.push(`${unchanged} already archived`);
+  }
+  return parts.join(", ");
+}
+
+export function OpportunityTable({
+  opportunities,
+  view,
+}: OpportunityTableProps) {
+  const [selection, setSelection] = useState<Set<string>>(new Set());
+  const [lastClickedIndex, setLastClickedIndex] = useState<number | null>(null);
+  const [isPending, startTransition] = useTransition();
+  const shiftPressedRef = useRef(false);
+  const searchParams = useSearchParams();
+  const bulkEnabled = view === "active";
+
+  // Clear selection whenever the URL search params change (filter chip click,
+  // search keystroke, archive-view toggle).
+  useEffect(() => {
+    setSelection(new Set());
+    setLastClickedIndex(null);
+  }, [searchParams]);
+
+  // Esc clears selection. Skip when focus is in an input/textarea or inside a
+  // dialog — those owners handle Esc themselves.
+  useEffect(() => {
+    if (selection.size === 0) return;
+    function handler(e: KeyboardEvent) {
+      if (e.key !== "Escape") return;
+      const target = e.target as HTMLElement | null;
+      if (target) {
+        const tag = target.tagName;
+        if (tag === "INPUT" || tag === "TEXTAREA" || target.isContentEditable) {
+          return;
+        }
+        if (target.closest("[role='dialog']")) return;
+      }
+      setSelection(new Set());
+      setLastClickedIndex(null);
+    }
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [selection.size]);
+
+  const allSelected =
+    opportunities.length > 0 && selection.size === opportunities.length;
+  const someSelected = selection.size > 0 && !allSelected;
+
+  function toggleAll() {
+    if (selection.size > 0) {
+      setSelection(new Set());
+      setLastClickedIndex(null);
+    } else {
+      setSelection(new Set(opportunities.map((o) => o.id)));
+    }
+  }
+
+  function toggleRow(index: number, useShift: boolean) {
+    const opp = opportunities[index];
+    setSelection((prev) => {
+      const next = new Set(prev);
+      if (useShift && lastClickedIndex !== null && lastClickedIndex !== index) {
+        const start = Math.min(lastClickedIndex, index);
+        const end = Math.max(lastClickedIndex, index);
+        // Apply the same target state across the range, derived from the
+        // clicked row's resulting state.
+        const targetChecked = !prev.has(opp.id);
+        for (let i = start; i <= end; i++) {
+          const id = opportunities[i].id;
+          if (targetChecked) next.add(id);
+          else next.delete(id);
+        }
+      } else {
+        if (next.has(opp.id)) next.delete(opp.id);
+        else next.add(opp.id);
+      }
+      return next;
+    });
+    setLastClickedIndex(index);
+  }
+
+  function clearSelection() {
+    setSelection(new Set());
+    setLastClickedIndex(null);
+  }
+
+  function handleBulkArchive() {
+    const ids = Array.from(selection);
+    if (ids.length === 0) return;
+    startTransition(async () => {
+      const result = await bulkArchive(ids);
+      clearSelection();
+
+      const summary = formatArchiveCounts(result.updated, result.unchanged);
+      if (result.failed > 0) {
+        const failedPart = `${result.failed} failed`;
+        toast.error(summary ? `${summary}, ${failedPart}` : failedPart);
+      } else if (result.updated > 0) {
+        toast.success(summary);
+      } else if (result.unchanged > 0) {
+        toast(summary);
+      }
+    });
+  }
+
   if (opportunities.length === 0) {
     return (
       <div className="text-center py-12 text-muted-foreground">
@@ -107,6 +226,9 @@ export function OpportunityTable({ opportunities }: OpportunityTableProps) {
     );
   }
 
+  const bulkBarOpen = bulkEnabled && selection.size > 0;
+  const desktopColCount = bulkEnabled ? 5 : 4;
+
   return (
     <>
       {/* Mobile: Card list */}
@@ -117,46 +239,128 @@ export function OpportunityTable({ opportunities }: OpportunityTableProps) {
       </div>
 
       {/* Desktop: Table */}
-      <div className="hidden md:block bg-card border rounded-lg overflow-hidden">
+      <div className="hidden md:block bg-card border rounded-lg overflow-clip">
         <Table>
-          <TableHeader className="bg-background">
-            <TableRow className="hover:bg-transparent border-b border-border">
-              <TableHead>Company & Role</TableHead>
-              <TableHead>Status</TableHead>
-              <TableHead>Applied Date</TableHead>
-              <TableHead>Last Contact</TableHead>
-            </TableRow>
+          <TableHeader className="bg-background sticky top-0 z-10">
+            {bulkBarOpen ? (
+              <TableRow className="hover:bg-transparent border-b border-border">
+                <TableHead
+                  colSpan={desktopColCount}
+                  className="h-10 whitespace-nowrap pl-4 pr-2"
+                >
+                  <div className="flex items-center gap-3">
+                    <Checkbox
+                      checked={allSelected || someSelected}
+                      indeterminate={someSelected}
+                      onCheckedChange={() => toggleAll()}
+                      aria-label={
+                        allSelected ? "Deselect all" : "Select all visible"
+                      }
+                    />
+                    <span className="text-sm font-semibold text-foreground">
+                      {selection.size} selected
+                    </span>
+                    <div className="ml-auto flex items-center gap-2">
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={handleBulkArchive}
+                        disabled={isPending}
+                      >
+                        {isPending ? (
+                          <span className="inline-block size-3.5 animate-spin rounded-full border-2 border-current border-t-transparent" />
+                        ) : (
+                          <Archive />
+                        )}
+                        Archive
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={clearSelection}
+                        disabled={isPending}
+                      >
+                        <X />
+                        Cancel
+                      </Button>
+                    </div>
+                  </div>
+                </TableHead>
+              </TableRow>
+            ) : (
+              <TableRow className="hover:bg-transparent border-b border-border">
+                {bulkEnabled && (
+                  <TableHead className="w-10 pl-4">
+                    <Checkbox
+                      checked={allSelected}
+                      indeterminate={false}
+                      onCheckedChange={() => toggleAll()}
+                      aria-label="Select all visible"
+                    />
+                  </TableHead>
+                )}
+                <TableHead className="w-full">Company &amp; Role</TableHead>
+                <TableHead className="min-w-[200px]">Status</TableHead>
+                <TableHead className="min-w-[180px]">Applied Date</TableHead>
+                <TableHead className="min-w-[180px]">Last Contact</TableHead>
+              </TableRow>
+            )}
           </TableHeader>
           <TableBody>
-            {opportunities.map((opp) => (
-              <TableRow key={opp.id}>
-                <TableCell className="py-4">
-                  <Link
-                    href={`/opportunities/${opp.id}`}
-                    className="hover:underline"
-                  >
-                    <div className="text-sm font-semibold text-foreground">
-                      {opp.company}
-                    </div>
-                    <div className="text-sm font-medium text-muted-foreground">
-                      {opp.role}
-                    </div>
-                  </Link>
-                </TableCell>
-                <TableCell>
-                  <StatusBadge
-                    status={opp.status as Status}
-                    opportunityId={opp.id}
-                  />
-                </TableCell>
-                <TableCell className="text-sm font-medium text-muted-foreground">
-                  {formatDate(opp.appliedAt)}
-                </TableCell>
-                <TableCell className="text-sm font-medium text-muted-foreground">
-                  {formatRelativeDate(opp.updatedAt)}
-                </TableCell>
-              </TableRow>
-            ))}
+            {opportunities.map((opp, index) => {
+              const selected = selection.has(opp.id);
+              return (
+                <TableRow
+                  key={opp.id}
+                  data-state={selected ? "selected" : undefined}
+                >
+                  {bulkEnabled && (
+                    <TableCell className="w-10 pl-4">
+                      <Checkbox
+                        checked={selected}
+                        onMouseDown={(e: React.MouseEvent) => {
+                          // Suppress the browser's native shift-click text
+                          // selection so range select doesn't paint the rows.
+                          if (e.shiftKey) e.preventDefault();
+                        }}
+                        onClick={(e: React.MouseEvent) => {
+                          shiftPressedRef.current = e.shiftKey;
+                        }}
+                        onCheckedChange={() =>
+                          toggleRow(index, shiftPressedRef.current)
+                        }
+                        aria-label={`Select ${opp.role} at ${opp.company}`}
+                      />
+                    </TableCell>
+                  )}
+                  <TableCell className="py-4">
+                    <Link
+                      href={`/opportunities/${opp.id}`}
+                      className="hover:underline"
+                    >
+                      <div className="text-sm font-semibold text-foreground">
+                        {opp.company}
+                      </div>
+                      <div className="text-sm font-medium text-muted-foreground">
+                        {opp.role}
+                      </div>
+                    </Link>
+                  </TableCell>
+                  <TableCell>
+                    <StatusBadge
+                      status={opp.status as Status}
+                      opportunityId={opp.id}
+                    />
+                  </TableCell>
+                  <TableCell className="text-sm font-medium text-muted-foreground">
+                    {formatDate(opp.appliedAt)}
+                  </TableCell>
+                  <TableCell className="text-sm font-medium text-muted-foreground">
+                    {formatRelativeDate(opp.updatedAt)}
+                  </TableCell>
+                </TableRow>
+              );
+            })}
           </TableBody>
         </Table>
       </div>

--- a/src/components/opportunity-table.tsx
+++ b/src/components/opportunity-table.tsx
@@ -313,6 +313,11 @@ export function OpportunityTable({
                 <TableRow
                   key={opp.id}
                   data-state={selected ? "selected" : undefined}
+                  className={
+                    selected
+                      ? "bg-primary/5 hover:bg-primary/10 data-[state=selected]:bg-primary/5"
+                      : undefined
+                  }
                 >
                   {bulkEnabled && (
                     <TableCell className="w-10 pl-4">

--- a/src/components/ui/checkbox.tsx
+++ b/src/components/ui/checkbox.tsx
@@ -16,7 +16,7 @@ function Checkbox({
       data-slot="checkbox"
       indeterminate={indeterminate}
       className={cn(
-        "peer inline-flex size-4 shrink-0 items-center justify-center rounded-[4px] border border-input bg-background text-current shadow-sm outline-none transition-colors focus-visible:ring-2 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 data-[checked]:border-primary data-[checked]:bg-primary data-[checked]:text-primary-foreground data-[indeterminate]:border-primary data-[indeterminate]:bg-primary data-[indeterminate]:text-primary-foreground",
+        "peer inline-flex size-4 shrink-0 items-center justify-center rounded-[4px] border border-input bg-background align-middle text-current shadow-sm outline-none transition-colors focus-visible:ring-2 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 data-[checked]:border-primary data-[checked]:bg-primary data-[checked]:text-primary-foreground data-[indeterminate]:border-primary data-[indeterminate]:bg-primary data-[indeterminate]:text-primary-foreground",
         className,
       )}
       {...props}

--- a/src/components/ui/checkbox.tsx
+++ b/src/components/ui/checkbox.tsx
@@ -1,0 +1,38 @@
+"use client"
+
+import * as React from "react"
+import { Checkbox as CheckboxPrimitive } from "@base-ui/react/checkbox"
+import { Check, Minus } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+function Checkbox({
+  className,
+  indeterminate,
+  ...props
+}: CheckboxPrimitive.Root.Props) {
+  return (
+    <CheckboxPrimitive.Root
+      data-slot="checkbox"
+      indeterminate={indeterminate}
+      className={cn(
+        "peer inline-flex size-4 shrink-0 items-center justify-center rounded-[4px] border border-input bg-background text-current shadow-sm outline-none transition-colors focus-visible:ring-2 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 data-[checked]:border-primary data-[checked]:bg-primary data-[checked]:text-primary-foreground data-[indeterminate]:border-primary data-[indeterminate]:bg-primary data-[indeterminate]:text-primary-foreground",
+        className,
+      )}
+      {...props}
+    >
+      <CheckboxPrimitive.Indicator
+        data-slot="checkbox-indicator"
+        className="flex items-center justify-center text-current"
+      >
+        {indeterminate ? (
+          <Minus className="size-3.5" strokeWidth={3} />
+        ) : (
+          <Check className="size-3.5" strokeWidth={3} />
+        )}
+      </CheckboxPrimitive.Indicator>
+    </CheckboxPrimitive.Root>
+  )
+}
+
+export { Checkbox }

--- a/src/lib/actions/opportunities.ts
+++ b/src/lib/actions/opportunities.ts
@@ -382,6 +382,51 @@ export async function archiveOpportunity(id: string) {
   revalidatePath("/opportunities");
 }
 
+export type BulkActionResult = {
+  updated: number;
+  unchanged: number;
+  failed: number;
+};
+
+export async function bulkArchive(ids: string[]): Promise<BulkActionResult> {
+  const userId = await requireUserId();
+  const result: BulkActionResult = { updated: 0, unchanged: 0, failed: 0 };
+
+  for (const id of ids) {
+    try {
+      const existing = await db
+        .select({ archived: opportunities.archived })
+        .from(opportunities)
+        .where(and(eq(opportunities.id, id), eq(opportunities.userId, userId)))
+        .limit(1);
+
+      if (!existing[0]) {
+        result.failed += 1;
+        continue;
+      }
+      if (existing[0].archived === 1) {
+        result.unchanged += 1;
+        continue;
+      }
+
+      await db
+        .update(opportunities)
+        .set({
+          archived: 1,
+          updatedAt: new Date().toISOString(),
+        })
+        .where(and(eq(opportunities.id, id), eq(opportunities.userId, userId)));
+
+      result.updated += 1;
+    } catch {
+      result.failed += 1;
+    }
+  }
+
+  revalidatePath("/opportunities");
+  return result;
+}
+
 export async function unarchiveOpportunity(id: string) {
   const userId = await requireUserId();
 


### PR DESCRIPTION
## Summary

- Adds an always-visible checkbox column to the desktop `/opportunities` table on the Active view
- Sticky bulk-actions bar swaps in for the column-header row when >=1 row is selected, with Archive + Cancel
- New `bulkArchive` server action runs per-item with try/catch and returns `{ updated, unchanged, failed }`

## What's in this slice

- Shift-click range select; Esc clears selection; Cancel button clears selection
- Selection clears on filter chip click, search keystroke, archive-view toggle, route change, and after the action completes
- Toast surfaces the per-item counts (e.g., "Archived 5 opportunities")
- Archive view (`?archived=true`) is intentionally unchanged in this slice — the table is passed `view="active" | "archive"` and bulk is gated to active only
- Mobile cards are unchanged

## What's deferred

- Bulk **status** change in the bar (#70)
- Bulk **unarchive** on the Archive view (#71)
- Mobile bulk operations (#72)

## Test plan

- [x] Desktop table renders a checkbox column with a tri-state header checkbox
- [x] Shift-clicking a row checkbox selects the range from the last-clicked row
- [x] When >=1 row is selected, the column-header row is replaced in-place by a sticky bar showing "{N} selected", Archive, Cancel
- [ ] Clicking Archive shows a pending spinner, then displays a toast with the archived count
- [ ] Esc key clears selection
- [ ] Cancel button clears selection
- [ ] Header tri-state checkbox: off -> select all; indeterminate/on -> deselect all
- [ ] Selection clears on filter chip click, search input change, archive-view toggle, route change, and after bulk action completes
- [ ] Archive view (`?archived=true`) is unchanged
- [ ] Mobile card view is unchanged

Closes #69.

🤖 Generated with [Claude Code](https://claude.com/claude-code)