### PR TITLE
Bulk unarchive on Archive list (desktop)

### DIFF
--- a/src/components/opportunity-table.tsx
+++ b/src/components/opportunity-table.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useRef, useState, useTransition } from "react";
 import { useSearchParams } from "next/navigation";
 import Link from "next/link";
-import { Archive, Calendar, X } from "lucide-react";
+import { Archive, ArchiveRestore, Calendar, X } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -23,7 +23,11 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { StatusBadge } from "@/components/status-badge";
-import { bulkArchive, bulkUpdateStatus } from "@/lib/actions/opportunities";
+import {
+  bulkArchive,
+  bulkUnarchive,
+  bulkUpdateStatus,
+} from "@/lib/actions/opportunities";
 import type { Opportunity } from "@/lib/db/schema";
 import {
   STATUSES,
@@ -125,6 +129,19 @@ function formatArchiveCounts(updated: number, unchanged: number): string {
   return parts.join(", ");
 }
 
+function formatUnarchiveCounts(updated: number, unchanged: number): string {
+  const parts: string[] = [];
+  if (updated > 0) {
+    parts.push(
+      `Unarchived ${updated} ${updated === 1 ? "opportunity" : "opportunities"}`,
+    );
+  }
+  if (unchanged > 0) {
+    parts.push(`${unchanged} not archived`);
+  }
+  return parts.join(", ");
+}
+
 function formatStatusCounts(
   updated: number,
   unchanged: number,
@@ -155,6 +172,7 @@ export function OpportunityTable({
   // gated to the Active list).
   const bulkEnabled = true;
   const canArchive = view === "active";
+  const canUnarchive = view === "archive";
 
   // Clear selection whenever the URL search params change (filter chip click,
   // search keystroke, archive-view toggle).
@@ -234,6 +252,25 @@ export function OpportunityTable({
       clearSelection();
 
       const summary = formatArchiveCounts(result.updated, result.unchanged);
+      if (result.failed > 0) {
+        const failedPart = `${result.failed} failed`;
+        toast.error(summary ? `${summary}, ${failedPart}` : failedPart);
+      } else if (result.updated > 0) {
+        toast.success(summary);
+      } else if (result.unchanged > 0) {
+        toast(summary);
+      }
+    });
+  }
+
+  function handleBulkUnarchive() {
+    const ids = Array.from(selection);
+    if (ids.length === 0) return;
+    startTransition(async () => {
+      const result = await bulkUnarchive(ids);
+      clearSelection();
+
+      const summary = formatUnarchiveCounts(result.updated, result.unchanged);
       if (result.failed > 0) {
         const failedPart = `${result.failed} failed`;
         toast.error(summary ? `${summary}, ${failedPart}` : failedPart);
@@ -356,6 +393,21 @@ export function OpportunityTable({
                             <Archive />
                           )}
                           Archive
+                        </Button>
+                      )}
+                      {canUnarchive && (
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          onClick={handleBulkUnarchive}
+                          disabled={isPending}
+                        >
+                          {isPending ? (
+                            <span className="inline-block size-3.5 animate-spin rounded-full border-2 border-current border-t-transparent" />
+                          ) : (
+                            <ArchiveRestore />
+                          )}
+                          Unarchive
                         </Button>
                       )}
                       <Button

--- a/src/lib/actions/opportunities.ts
+++ b/src/lib/actions/opportunities.ts
@@ -477,6 +477,47 @@ export async function bulkUpdateStatus(
   return result;
 }
 
+export async function bulkUnarchive(
+  ids: string[]
+): Promise<BulkActionResult> {
+  const userId = await requireUserId();
+  const result: BulkActionResult = { updated: 0, unchanged: 0, failed: 0 };
+
+  for (const id of ids) {
+    try {
+      const existing = await db
+        .select({ archived: opportunities.archived })
+        .from(opportunities)
+        .where(and(eq(opportunities.id, id), eq(opportunities.userId, userId)))
+        .limit(1);
+
+      if (!existing[0]) {
+        result.failed += 1;
+        continue;
+      }
+      if (existing[0].archived === 0) {
+        result.unchanged += 1;
+        continue;
+      }
+
+      await db
+        .update(opportunities)
+        .set({
+          archived: 0,
+          updatedAt: new Date().toISOString(),
+        })
+        .where(and(eq(opportunities.id, id), eq(opportunities.userId, userId)));
+
+      result.updated += 1;
+    } catch {
+      result.failed += 1;
+    }
+  }
+
+  revalidatePath("/opportunities");
+  return result;
+}
+
 export async function unarchiveOpportunity(id: string) {
   const userId = await requireUserId();
 


### PR DESCRIPTION
## Summary

- Adds an Unarchive button to the bulk-actions bar when viewing the Archive list (\`?archived=true\`)
- New \`bulkUnarchive\` server action runs per-item with try/catch and returns \`{ updated, unchanged, failed }\`
- The Active list bar is unchanged — Archive button stays put

## What's in this slice

- Primary action label flips based on the \`archived\` query param: **Archive** on the Active list, **Unarchive** on the Archive list
- Toast surfaces the counts: \"Unarchived 3 opportunities, 1 not archived\"
- All previously-confirmed behaviors from #69/#70 still apply

## What's deferred

- Mobile bulk operations (#72)

## Test plan

- [ ] On \`?archived=true\`, the primary action in the bulk bar reads **Unarchive**
- [ ] Clicking Unarchive fires \`bulkUnarchive(ids)\` and unarchived items disappear from the Archive list
- [ ] Server action returns \`{ updated, unchanged, failed }\` with per-item try/catch
- [ ] Pending spinner shown during action
- [ ] Success toast shows the unarchived count
- [ ] On the Active list, the primary action still reads Archive (unchanged behavior)
- [ ] Bulk status change still works on both views

Closes #71.

🤖 Generated with [Claude Code](https://claude.com/claude-code)