### PR TITLE
Sortable column headers on desktop (#79)

### DIFF
--- a/src/components/opportunity-table.tsx
+++ b/src/components/opportunity-table.tsx
@@ -22,6 +22,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import { SortableHeader } from "@/components/sortable-header";
 import { StatusBadge } from "@/components/status-badge";
 import {
   bulkArchive,
@@ -35,6 +36,7 @@ import {
   STATUS_LABELS,
   type Status,
 } from "@/lib/constants";
+import { parseSortParams } from "@/lib/sort/parse-sort-params";
 
 interface OpportunityTableProps {
   opportunities: Opportunity[];
@@ -170,6 +172,10 @@ export function OpportunityTable({
   const [isPending, startTransition] = useTransition();
   const shiftPressedRef = useRef(false);
   const searchParams = useSearchParams();
+  const currentSort = parseSortParams({
+    sort: searchParams.get("sort") ?? undefined,
+    dir: searchParams.get("dir") ?? undefined,
+  });
   // Bulk selection is enabled on both views — status change is meaningful in
   // either. The action set in the bar varies by view (Archive button is
   // gated to the Active list).
@@ -438,10 +444,34 @@ export function OpportunityTable({
                     />
                   </TableHead>
                 )}
-                <TableHead className="w-full pl-4">Company &amp; Role</TableHead>
-                <TableHead className="min-w-[200px]">Status</TableHead>
-                <TableHead className="min-w-[180px]">Applied Date</TableHead>
-                <TableHead className="min-w-[180px]">Last Activity</TableHead>
+                <SortableHeader
+                  column="company"
+                  currentSort={currentSort}
+                  className="w-full pl-4"
+                >
+                  Company &amp; Role
+                </SortableHeader>
+                <SortableHeader
+                  column="status"
+                  currentSort={currentSort}
+                  className="min-w-[200px]"
+                >
+                  Status
+                </SortableHeader>
+                <SortableHeader
+                  column="applied_at"
+                  currentSort={currentSort}
+                  className="min-w-[180px]"
+                >
+                  Applied Date
+                </SortableHeader>
+                <SortableHeader
+                  column="updated_at"
+                  currentSort={currentSort}
+                  className="min-w-[180px]"
+                >
+                  Last Activity
+                </SortableHeader>
               </TableRow>
             )}
           </TableHeader>

--- a/src/components/sortable-header.tsx
+++ b/src/components/sortable-header.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { useRouter, useSearchParams } from "next/navigation";
+import { TableHead } from "@/components/ui/table";
+import { cn } from "@/lib/utils";
+import { nextSortState } from "@/lib/sort/next-sort-state";
+import type { SortColumn, SortState } from "@/lib/sort/types";
+
+interface SortableHeaderProps {
+  column: SortColumn;
+  currentSort: SortState | null;
+  className?: string;
+  children: React.ReactNode;
+}
+
+export function SortableHeader({
+  column,
+  currentSort,
+  className,
+  children,
+}: SortableHeaderProps) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const isActive = currentSort?.column === column;
+  const direction = isActive ? currentSort.direction : null;
+
+  function handleClick() {
+    const next = nextSortState(currentSort, column);
+    const params = new URLSearchParams(searchParams.toString());
+    if (next === null) {
+      params.delete("sort");
+      params.delete("dir");
+    } else {
+      params.set("sort", next.column);
+      params.set("dir", next.direction);
+    }
+    const query = params.toString();
+    router.push(query ? `/opportunities?${query}` : "/opportunities");
+  }
+
+  return (
+    <TableHead
+      className={cn(
+        "group cursor-pointer select-none",
+        className,
+      )}
+      onClick={handleClick}
+      aria-sort={
+        direction === "asc"
+          ? "ascending"
+          : direction === "desc"
+            ? "descending"
+            : "none"
+      }
+    >
+      <span className="inline-flex items-center gap-1">
+        {children}
+        {direction === "asc" ? (
+          <span aria-hidden="true" className="text-foreground">
+            ▲
+          </span>
+        ) : direction === "desc" ? (
+          <span aria-hidden="true" className="text-foreground">
+            ▼
+          </span>
+        ) : (
+          <span
+            aria-hidden="true"
+            className="text-muted-foreground/40 opacity-0 group-hover:opacity-100"
+          >
+            ↕
+          </span>
+        )}
+      </span>
+    </TableHead>
+  );
+}

--- a/src/lib/sort/next-sort-state.test.ts
+++ b/src/lib/sort/next-sort-state.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import { nextSortState } from "./next-sort-state";
+
+describe("nextSortState", () => {
+  it("returns ASC for the clicked column when none is active", () => {
+    expect(nextSortState(null, "company")).toEqual({
+      column: "company",
+      direction: "asc",
+    });
+    expect(nextSortState(null, "status")).toEqual({
+      column: "status",
+      direction: "asc",
+    });
+  });
+
+  it("flips ASC → DESC when clicking the active column", () => {
+    expect(
+      nextSortState({ column: "company", direction: "asc" }, "company"),
+    ).toEqual({ column: "company", direction: "desc" });
+  });
+
+  it("returns null when clicking the active DESC column (clears sort)", () => {
+    expect(
+      nextSortState({ column: "company", direction: "desc" }, "company"),
+    ).toBeNull();
+  });
+
+  it("starts a new column at ASC when switching from a different active column", () => {
+    expect(
+      nextSortState({ column: "company", direction: "asc" }, "status"),
+    ).toEqual({ column: "status", direction: "asc" });
+    expect(
+      nextSortState({ column: "company", direction: "desc" }, "applied_at"),
+    ).toEqual({ column: "applied_at", direction: "asc" });
+  });
+});

--- a/src/lib/sort/next-sort-state.ts
+++ b/src/lib/sort/next-sort-state.ts
@@ -1,0 +1,14 @@
+import type { SortColumn, SortState } from "./types";
+
+export function nextSortState(
+  current: SortState | null,
+  clicked: SortColumn,
+): SortState | null {
+  if (current === null || current.column !== clicked) {
+    return { column: clicked, direction: "asc" };
+  }
+  if (current.direction === "asc") {
+    return { column: clicked, direction: "desc" };
+  }
+  return null;
+}


### PR DESCRIPTION
Implements the desktop UX from PRD #77: clicking any of the four sortable headers (Company & Role, Status, Applied Date, Last Activity) follows a 3-click cycle per column (inactive → ASC → DESC → cleared) and updates `?sort=<col>&dir=<asc|desc>` in the URL.

- 3-click cycle extracted into a pure `nextSortState` module (unit-tested in isolation)
- `SortableHeader` is a thin router/navigation shell using `useSearchParams()` so sibling params (status, search, archived) are preserved
- Active column shows a solid ▲/▼; inactive sortable headers show a greyed ↕ hover hint; whole `<th>` is the click target
- `aria-sort` set for accessibility

## Files
- `src/lib/sort/next-sort-state.ts` (new) — 3-click cycle pure helper
- `src/lib/sort/next-sort-state.test.ts` (new) — tests
- `src/components/sortable-header.tsx` (new) — TH wrapper
- `src/components/opportunity-table.tsx` — wire SortableHeader for the four sortable columns

## Notes
Originally produced by a Sandcastle ralph-loop run, which committed it to local `main` only and closed issue #79 without pushing. This PR publishes that work for review. Verified by the run: 19 unit tests pass, typecheck clean, lint clean (no new warnings), dev-server smoke check on `?sort=company&dir=asc` and `?sort=updated_at&dir=desc`.

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)