### PR TITLE
Mobile sort sheet for the opportunity list (#80)

### DIFF
--- a/src/app/(app)/opportunities/page.tsx
+++ b/src/app/(app)/opportunities/page.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
+import { MobileSortSheet } from "@/components/mobile-sort-sheet";
 import { OpportunityTable } from "@/components/opportunity-table";
 import { StatusFilter } from "@/components/status-filter";
 import { listOpportunities, getStatusCounts } from "@/lib/actions/opportunities";
@@ -56,6 +57,11 @@ export default async function OpportunitiesPage({ searchParams }: PageProps) {
 
       {/* Filters */}
       <StatusFilter selected={statusFilter} counts={statusCounts} searchParams={params} />
+
+      {/* Mobile-only sort pill, between filter chips and the card list */}
+      <div className="md:hidden">
+        <MobileSortSheet />
+      </div>
 
       {/* Table */}
       <OpportunityTable

--- a/src/components/mobile-sort-sheet.tsx
+++ b/src/components/mobile-sort-sheet.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { Dialog as DialogPrimitive } from "@base-ui/react/dialog";
+import { Check, ChevronDown } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { parseSortParams } from "@/lib/sort/parse-sort-params";
+import {
+  DEFAULT_SORT_COLUMN,
+  SORT_COLUMN_LABELS,
+  SORT_NATURAL_DESCRIPTORS,
+} from "@/lib/sort/labels";
+import { SORT_COLUMNS, type SortColumn } from "@/lib/sort/types";
+
+export function MobileSortSheet() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const [open, setOpen] = useState(false);
+
+  const currentSort = parseSortParams({
+    sort: searchParams.get("sort") ?? undefined,
+    dir: searchParams.get("dir") ?? undefined,
+  });
+  const activeColumn: SortColumn = currentSort?.column ?? DEFAULT_SORT_COLUMN;
+
+  function applyColumn(column: SortColumn) {
+    if (column === activeColumn) {
+      setOpen(false);
+      return;
+    }
+    const params = new URLSearchParams(searchParams.toString());
+    if (column === DEFAULT_SORT_COLUMN) {
+      params.delete("sort");
+      params.delete("dir");
+    } else {
+      params.set("sort", column);
+      params.delete("dir");
+    }
+    const query = params.toString();
+    router.push(query ? `/opportunities?${query}` : "/opportunities");
+    setOpen(false);
+  }
+
+  return (
+    <DialogPrimitive.Root open={open} onOpenChange={setOpen}>
+      <DialogPrimitive.Trigger
+        className="inline-flex items-center gap-1.5 rounded-full bg-secondary px-3 py-1.5 text-sm font-semibold text-secondary-foreground shadow-sm hover:bg-secondary/80"
+        aria-label={`Sort: ${SORT_COLUMN_LABELS[activeColumn]}`}
+      >
+        <span className="text-muted-foreground">Sort:</span>
+        <span>{SORT_COLUMN_LABELS[activeColumn]}</span>
+        <ChevronDown className="size-3.5 text-muted-foreground" aria-hidden />
+      </DialogPrimitive.Trigger>
+      <DialogPrimitive.Portal>
+        <DialogPrimitive.Backdrop
+          className={cn(
+            "fixed inset-0 isolate z-50 bg-black/40 duration-150",
+            "data-open:animate-in data-open:fade-in-0",
+            "data-closed:animate-out data-closed:fade-out-0",
+          )}
+        />
+        <DialogPrimitive.Popup
+          className={cn(
+            "fixed inset-x-0 bottom-0 z-50 flex flex-col gap-1 rounded-t-2xl bg-popover p-3 pb-[max(env(safe-area-inset-bottom),0.75rem)] text-popover-foreground shadow-lg ring-1 ring-foreground/10 outline-none duration-150",
+            "data-open:animate-in data-open:slide-in-from-bottom",
+            "data-closed:animate-out data-closed:slide-out-to-bottom",
+          )}
+        >
+          <DialogPrimitive.Title className="px-3 pt-1 pb-2 text-sm font-semibold text-muted-foreground">
+            Sort by
+          </DialogPrimitive.Title>
+          <ul className="flex flex-col">
+            {SORT_COLUMNS.map((column) => {
+              const isActive = column === activeColumn;
+              return (
+                <li key={column}>
+                  <button
+                    type="button"
+                    onClick={() => applyColumn(column)}
+                    aria-pressed={isActive}
+                    className={cn(
+                      "flex w-full items-center gap-3 rounded-lg px-3 py-3 text-left text-[0.9375rem] font-medium",
+                      isActive
+                        ? "bg-primary/5 text-foreground"
+                        : "text-foreground hover:bg-muted/60",
+                    )}
+                  >
+                    <Check
+                      className={cn(
+                        "size-4 shrink-0",
+                        isActive ? "text-primary" : "opacity-0",
+                      )}
+                      aria-hidden
+                    />
+                    <span className="flex-1">
+                      {SORT_COLUMN_LABELS[column]}
+                      <span className="ml-2 text-sm font-normal text-muted-foreground">
+                        — {SORT_NATURAL_DESCRIPTORS[column]}
+                      </span>
+                    </span>
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        </DialogPrimitive.Popup>
+      </DialogPrimitive.Portal>
+    </DialogPrimitive.Root>
+  );
+}

--- a/src/lib/sort/labels.test.ts
+++ b/src/lib/sort/labels.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+import { SORT_COLUMNS } from "./types";
+import {
+  SORT_COLUMN_LABELS,
+  SORT_NATURAL_DESCRIPTORS,
+  DEFAULT_SORT_COLUMN,
+} from "./labels";
+
+describe("sort labels", () => {
+  it("exposes a human label for every sortable column", () => {
+    for (const column of SORT_COLUMNS) {
+      expect(SORT_COLUMN_LABELS[column]).toBeTruthy();
+    }
+  });
+
+  it("uses the user-facing column names from the PRD", () => {
+    expect(SORT_COLUMN_LABELS.updated_at).toBe("Last Activity");
+    expect(SORT_COLUMN_LABELS.company).toBe("Company");
+    expect(SORT_COLUMN_LABELS.status).toBe("Status");
+    expect(SORT_COLUMN_LABELS.applied_at).toBe("Applied Date");
+  });
+
+  it("provides the natural-direction descriptor for each column", () => {
+    expect(SORT_NATURAL_DESCRIPTORS.updated_at).toBe("newest first");
+    expect(SORT_NATURAL_DESCRIPTORS.company).toBe("A–Z");
+    expect(SORT_NATURAL_DESCRIPTORS.status).toBe("workflow order");
+    expect(SORT_NATURAL_DESCRIPTORS.applied_at).toBe("most recent");
+  });
+
+  it("treats updated_at (Last Activity) as the default sort column", () => {
+    expect(DEFAULT_SORT_COLUMN).toBe("updated_at");
+  });
+});

--- a/src/lib/sort/labels.ts
+++ b/src/lib/sort/labels.ts
@@ -1,0 +1,24 @@
+import type { SortColumn, SortDirection } from "./types";
+
+export const SORT_COLUMN_LABELS: Record<SortColumn, string> = {
+  company: "Company",
+  status: "Status",
+  applied_at: "Applied Date",
+  updated_at: "Last Activity",
+};
+
+export const SORT_NATURAL_DESCRIPTORS: Record<SortColumn, string> = {
+  company: "A–Z",
+  status: "workflow order",
+  applied_at: "most recent",
+  updated_at: "newest first",
+};
+
+export const SORT_NATURAL_DIRECTIONS: Record<SortColumn, SortDirection> = {
+  company: "asc",
+  status: "asc",
+  applied_at: "desc",
+  updated_at: "desc",
+};
+
+export const DEFAULT_SORT_COLUMN: SortColumn = "updated_at";


### PR DESCRIPTION
Implements the mobile sort UX from PRD #77. On viewports below `md`, a `Sort: <current> ▾` pill renders between the filter chips and the card list. Tapping it opens a bottom sheet listing the four sortable columns with their natural-direction descriptors; a single tap applies that sort, updates the URL, and closes the sheet.

- No direction toggle on mobile (Simple mode) — each option applies its natural direction, so the URL gets `?sort=<col>` with no `dir` param
- Selecting the default column (Last Activity) clears `sort`/`dir`; selecting the already-active column just closes the sheet
- Bottom sheet respects `env(safe-area-inset-bottom)`
- Column labels and natural-direction descriptors extracted into a pure `src/lib/sort/labels.ts` module with unit tests
- Desktop column-header sort is unchanged

## Files
- `src/lib/sort/labels.ts` (new) — labels, descriptors, default column
- `src/lib/sort/labels.test.ts` (new) — tests
- `src/components/mobile-sort-sheet.tsx` (new) — pill + bottom sheet
- `src/app/(app)/opportunities/page.tsx` — render the pill, mobile-only

## Verification
19 unit tests pass, typecheck clean, lint clean. Manual Playwright smoke check at a 390px viewport: the pill opens the sheet, the active option shows a checkmark, and selecting Company updates the URL to `?sort=company` (no `dir`), closes the sheet, and re-sorts the list A–Z.

## Notes
A Sandcastle ralph-loop run started this work but ran out of credit before committing — it was left uncommitted in a worktree. This PR finishes it: browser-verified, committed, and opened for review.

Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)