### PR TITLE
Gate unbuilt pages behind Vercel feature flags (#61)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,3 +43,10 @@ FIRECRAWL_API_URL=https://api.firecrawl.dev/v2
 FIRECRAWL_TIMEOUT_MS=30000
 FIRECRAWL_MAX_AGE_MS=0
 FIRECRAWL_PROXY=auto
+
+# Feature flags — set to "true" to enable an unfinished feature.
+# Default off everywhere; flip on per-environment (local / Vercel Preview / Production).
+FLAG_DASHBOARD=
+FLAG_INSIGHTS=
+FLAG_SETTINGS=
+FLAG_ALERTS=

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,7 @@ npm run import -- <csv>  # Import opportunities from CSV
 - Email magic link requires `AUTH_RESEND_KEY` (Resend API key) and optionally `AUTH_EMAIL_FROM`
 - Next.js 16 uses `proxy.ts` instead of `middleware.ts`
 - Drizzle config requires `dialect: "turso"` (not `"sqlite"`) when using `TURSO_DATABASE_URL`
+- Feature flags (gating unbuilt pages) are defined in `src/lib/flags.ts` — add new flags there; see `docs/adr/0001-vercel-flags-sdk-over-env-checks.md`
 
 ## Project Decisions
 

--- a/README.md
+++ b/README.md
@@ -217,6 +217,18 @@ Then run:
 npm run import -- path/to/your-data.csv local-dev-user
 ```
 
+## Feature flags
+
+Unfinished pages (Dashboard, Insights, Settings, Alerts) are hidden behind feature flags built on the [Vercel Flags SDK](https://flags-sdk.dev/). When a flag is off, the sidebar link is hidden and the route returns 404; when it's on, the link appears and the page renders.
+
+Flags default to **off** in every environment. Each is controlled by a `FLAG_*` environment variable — set it to `"true"` to enable that feature:
+
+- **Locally** — add `FLAG_DASHBOARD=true` (etc.) to `.env.local`.
+- **Vercel Preview** — set the `FLAG_*` var on the Preview environment scope to dogfood an in-progress feature via a preview link, without exposing it in Production.
+- **Vercel Production** — set the `FLAG_*` var on the Production scope when the feature is ready to ship.
+
+Flag definitions live in [src/lib/flags.ts](src/lib/flags.ts) — add new flags there.
+
 ## Scripts
 
 | Command | Description |

--- a/README.md
+++ b/README.md
@@ -221,11 +221,13 @@ npm run import -- path/to/your-data.csv local-dev-user
 
 Unfinished pages (Dashboard, Insights, Settings, Alerts) are hidden behind feature flags built on the [Vercel Flags SDK](https://flags-sdk.dev/). When a flag is off, the sidebar link is hidden and the route returns 404; when it's on, the link appears and the page renders.
 
-Flags default to **off** in every environment. Each is controlled by a `FLAG_*` environment variable — set it to `"true"` to enable that feature:
+Flags default to **off** in every environment. Each is controlled by a `FLAG_*` **environment variable** — set it to `true` to enable that feature:
 
 - **Locally** — add `FLAG_DASHBOARD=true` (etc.) to `.env.local`.
-- **Vercel Preview** — set the `FLAG_*` var on the Preview environment scope to dogfood an in-progress feature via a preview link, without exposing it in Production.
-- **Vercel Production** — set the `FLAG_*` var on the Production scope when the feature is ready to ship.
+- **Vercel Preview** — add the `FLAG_*` var under **Settings → Environment Variables**, scoped to the Preview environment, to dogfood an in-progress feature via a preview link without exposing it in Production.
+- **Vercel Production** — add the `FLAG_*` var scoped to the Production environment when the feature is ready to ship.
+
+> **Use Environment Variables, not the Vercel Flags dashboard.** Vercel's dashboard has a separate "Flags" feature (with per-environment "Rules") whose values live in Edge Config — `process.env` is never populated from it, so the code here cannot read it. These flags are plain environment variables. A Vercel env-var change only takes effect after a **redeploy** of that environment.
 
 Flag definitions live in [src/lib/flags.ts](src/lib/flags.ts) — add new flags there.
 

--- a/docs/adr/0001-vercel-flags-sdk-over-env-checks.md
+++ b/docs/adr/0001-vercel-flags-sdk-over-env-checks.md
@@ -1,0 +1,11 @@
+# Use the Vercel Flags SDK for feature flags, not raw env-var checks
+
+We gate unbuilt pages (Dashboard, Insights, Settings, Alerts) behind feature flags defined with the Vercel Flags SDK (`flags/next`), each flag using an inline `decide` that reads a `FLAG_*` environment variable. A plain `process.env.FLAG_X === "true"` check would work identically today, since all toggling happens at deploy time for this single-user app — so the SDK looks like overkill at the call sites (`await dashboardFlag()`).
+
+We chose the SDK anyway because it keeps two future doors open with a one-line change per flag: swapping the inline `decide` for an adapter like `@flags-sdk/edge-config` to get runtime toggling without a redeploy, and adding an `identify` function for per-user flag evaluation once multi-user (issue #1) lands. Raw env checks would force a rewrite of every call site to gain either.
+
+## Consequences
+
+- Adds the `flags` dependency.
+- Evaluating a flag in a page or layout reads request context, opting that route out of static rendering. Acceptable here — the gated pages are stubs and the `(app)` layout is already dynamic (reads the session).
+- Each flag is temporary: when its feature ships, delete the flag, its `notFound()` guard, and its sidebar gate as part of that feature's PR.

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "drizzle-orm": "^0.45.2",
+        "flags": "^4.0.6",
         "highlight.js": "^11.11.1",
         "lucide-react": "^1.7.0",
         "nanoid": "^5.1.7",
@@ -912,6 +913,15 @@
         "@noble/ciphers": "^1.0.0"
       }
     },
+    "node_modules/@edge-runtime/cookies": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@edge-runtime/cookies/-/cookies-5.0.2.tgz",
+      "integrity": "sha512-Sd8LcWpZk/SWEeKGE8LT6gMm5MGfX/wm+GPnh1eBEtCpya3vYqn37wYknwAHw92ONoyyREl1hJwxV/Qx2DWNOg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/@effect/cli": {
       "version": "0.74.0",
       "resolved": "https://registry.npmjs.org/@effect/cli/-/cli-0.74.0.tgz",
@@ -1100,6 +1110,7 @@
       "integrity": "sha512-sOTzsC+ICASgSmX1RITYo6ut7ZbkX+hMG6YagJEyhtptxco9MgSflpF/ix/L92haJ+YTS5Zur/Dm2bDNfVes4w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "uuid": "^11.0.3"
       },
@@ -8228,6 +8239,49 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/flags": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/flags/-/flags-4.0.6.tgz",
+      "integrity": "sha512-8Rz/5L8Gkl2+LmlV2gOXx3iJNTYDooa8eGvshFev9nrXtrcvsXa5z/DXdtElHvN15psnSHg+r51lYHge2rCASw==",
+      "license": "MIT",
+      "dependencies": {
+        "@edge-runtime/cookies": "^5.0.2",
+        "jose": "^5.10.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.7.0",
+        "@sveltejs/kit": "*",
+        "next": "*",
+        "react": "*",
+        "react-dom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/flags/node_modules/jose": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
+      "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/flat-cache": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
@@ -11651,6 +11705,7 @@
       "resolved": "https://registry.npmjs.org/next/-/next-16.2.2.tgz",
       "integrity": "sha512-i6AJdyVa4oQjyvX/6GeER8dpY/xlIV+4NMv/svykcLtURJSy/WzDnnUk/TM4d0uewFHK7xSQz4TbIwPgjky+3A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@next/env": "16.2.2",
         "@swc/helpers": "0.5.15",
@@ -16607,7 +16662,6 @@
       "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "drizzle-orm": "^0.45.2",
+    "flags": "^4.0.6",
     "highlight.js": "^11.11.1",
     "lucide-react": "^1.7.0",
     "nanoid": "^5.1.7",

--- a/src/app/(app)/alerts/page.tsx
+++ b/src/app/(app)/alerts/page.tsx
@@ -1,0 +1,16 @@
+import { notFound } from "next/navigation";
+import { alertsFlag } from "@/lib/flags";
+
+export default async function AlertsPage() {
+  if (!(await alertsFlag())) notFound();
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-[1.875rem] font-bold tracking-[-0.025em] text-foreground">Alerts</h1>
+      <p className="text-sm font-medium text-muted-foreground">
+        Alerts and notifications coming soon. This will let you know about
+        deadlines and follow-ups in your job search.
+      </p>
+    </div>
+  );
+}

--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -1,4 +1,9 @@
-export default function DashboardPage() {
+import { notFound } from "next/navigation";
+import { dashboardFlag } from "@/lib/flags";
+
+export default async function DashboardPage() {
+  if (!(await dashboardFlag())) notFound();
+
   return (
     <div className="space-y-4">
       <h1 className="text-[1.875rem] font-bold tracking-[-0.025em] text-foreground">Dashboard</h1>

--- a/src/app/(app)/insights/page.tsx
+++ b/src/app/(app)/insights/page.tsx
@@ -1,4 +1,9 @@
-export default function InsightsPage() {
+import { notFound } from "next/navigation";
+import { insightsFlag } from "@/lib/flags";
+
+export default async function InsightsPage() {
+  if (!(await insightsFlag())) notFound();
+
   return (
     <div className="space-y-4">
       <h1 className="text-[1.875rem] font-bold tracking-[-0.025em] text-foreground">Insights</h1>

--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -1,5 +1,12 @@
 import { getOptionalSession, isAuthEnabled } from "@/lib/auth-optional";
 import { AppShell } from "@/components/layout/app-shell";
+import {
+  dashboardFlag,
+  insightsFlag,
+  settingsFlag,
+  alertsFlag,
+} from "@/lib/flags";
+import type { FeatureFlags } from "@/components/layout/nav-items";
 
 export default async function AppLayout({
   children,
@@ -8,8 +15,19 @@ export default async function AppLayout({
 }>) {
   const session = await getOptionalSession();
 
+  const flags: FeatureFlags = {
+    dashboard: await dashboardFlag(),
+    insights: await insightsFlag(),
+    settings: await settingsFlag(),
+    alerts: await alertsFlag(),
+  };
+
   return (
-    <AppShell user={session?.user ?? null} authEnabled={isAuthEnabled()}>
+    <AppShell
+      user={session?.user ?? null}
+      authEnabled={isAuthEnabled()}
+      flags={flags}
+    >
       {children}
     </AppShell>
   );

--- a/src/app/(app)/settings/page.tsx
+++ b/src/app/(app)/settings/page.tsx
@@ -1,4 +1,9 @@
-export default function SettingsPage() {
+import { notFound } from "next/navigation";
+import { settingsFlag } from "@/lib/flags";
+
+export default async function SettingsPage() {
+  if (!(await settingsFlag())) notFound();
+
   return (
     <div className="space-y-4">
       <h1 className="text-[1.875rem] font-bold tracking-[-0.025em] text-foreground">Settings</h1>

--- a/src/components/layout/app-shell.tsx
+++ b/src/components/layout/app-shell.tsx
@@ -3,14 +3,16 @@
 import { Suspense, useState } from "react";
 import { Sidebar } from "./sidebar";
 import { TopBar } from "./top-bar";
+import type { FeatureFlags } from "./nav-items";
 
 interface AppShellProps {
   children: React.ReactNode;
   user: { name?: string | null; email?: string | null; image?: string | null } | null;
   authEnabled: boolean;
+  flags: FeatureFlags;
 }
 
-export function AppShell({ children, user, authEnabled }: AppShellProps) {
+export function AppShell({ children, user, authEnabled, flags }: AppShellProps) {
   const [collapsed, setCollapsed] = useState(false);
   const [mobileOpen, setMobileOpen] = useState(false);
 
@@ -21,6 +23,7 @@ export function AppShell({ children, user, authEnabled }: AppShellProps) {
           collapsed={collapsed}
           onToggle={() => setCollapsed((c) => !c)}
           authEnabled={authEnabled}
+          flags={flags}
           mobileOpen={mobileOpen}
           onMobileClose={() => setMobileOpen(false)}
         />
@@ -29,6 +32,7 @@ export function AppShell({ children, user, authEnabled }: AppShellProps) {
         <Suspense fallback={<div className="h-14 shrink-0 border-b" />}>
           <TopBar
             user={user}
+            showAlerts={flags.alerts}
             onMobileMenuClick={() => setMobileOpen(true)}
           />
         </Suspense>

--- a/src/components/layout/nav-items.test.ts
+++ b/src/components/layout/nav-items.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+import {
+  navItems,
+  bottomItems,
+  filterNavItems,
+  type FeatureFlags,
+} from "./nav-items";
+
+const allOff: FeatureFlags = {
+  dashboard: false,
+  insights: false,
+  settings: false,
+  alerts: false,
+};
+
+describe("filterNavItems", () => {
+  it("keeps unflagged items regardless of flag values", () => {
+    const result = filterNavItems(navItems, allOff);
+    expect(result.map((i) => i.label)).toEqual(["Opportunities", "Archive"]);
+  });
+
+  it("hides every flagged item when all flags are off", () => {
+    expect(filterNavItems(navItems, allOff)).not.toContainEqual(
+      expect.objectContaining({ flag: expect.anything() })
+    );
+    expect(filterNavItems(bottomItems, allOff)).toEqual([]);
+  });
+
+  it("shows a flagged item only when its own flag is on", () => {
+    const result = filterNavItems(navItems, { ...allOff, insights: true });
+    expect(result.map((i) => i.label)).toEqual([
+      "Opportunities",
+      "Insights",
+      "Archive",
+    ]);
+  });
+
+  it("gates the Settings bottom item on the settings flag", () => {
+    expect(filterNavItems(bottomItems, allOff)).toEqual([]);
+    expect(
+      filterNavItems(bottomItems, { ...allOff, settings: true }).map((i) => i.label)
+    ).toEqual(["Settings"]);
+  });
+
+  it("shows all items when every flag is on", () => {
+    const allOn: FeatureFlags = {
+      dashboard: true,
+      insights: true,
+      settings: true,
+      alerts: true,
+    };
+    expect(filterNavItems(navItems, allOn)).toHaveLength(navItems.length);
+    expect(filterNavItems(bottomItems, allOn)).toHaveLength(bottomItems.length);
+  });
+});

--- a/src/components/layout/nav-items.ts
+++ b/src/components/layout/nav-items.ts
@@ -1,0 +1,43 @@
+import type { ComponentType } from "react";
+import {
+  LayoutDashboard,
+  Briefcase,
+  BarChart3,
+  Bell,
+  Archive,
+  Settings,
+} from "lucide-react";
+
+/** Feature flags that gate an unbuilt page — see src/lib/flags.ts. */
+export type FeatureFlag = "dashboard" | "insights" | "settings" | "alerts";
+
+/** Evaluated flag values, as forwarded from the (app) layout. */
+export type FeatureFlags = Record<FeatureFlag, boolean>;
+
+export interface NavItem {
+  href: string;
+  label: string;
+  icon: ComponentType<{ className?: string }>;
+  /** When set, the item is shown only if the matching flag is enabled. */
+  flag?: FeatureFlag;
+}
+
+export const navItems: NavItem[] = [
+  { href: "/dashboard", label: "Dashboard", icon: LayoutDashboard, flag: "dashboard" },
+  { href: "/opportunities", label: "Opportunities", icon: Briefcase },
+  { href: "/insights", label: "Insights", icon: BarChart3, flag: "insights" },
+  { href: "/alerts", label: "Alerts", icon: Bell, flag: "alerts" },
+  { href: "/opportunities?archived=true", label: "Archive", icon: Archive },
+];
+
+export const bottomItems: NavItem[] = [
+  { href: "/settings", label: "Settings", icon: Settings, flag: "settings" },
+];
+
+/**
+ * Drop nav items whose feature flag is off. Items without a `flag` (e.g.
+ * Opportunities, Archive) are always kept.
+ */
+export function filterNavItems(items: NavItem[], flags: FeatureFlags): NavItem[] {
+  return items.filter((item) => !item.flag || flags[item.flag]);
+}

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -3,11 +3,7 @@
 import Link from "next/link";
 import { usePathname, useSearchParams } from "next/navigation";
 import {
-  LayoutDashboard,
   Briefcase,
-  BarChart3,
-  Archive,
-  Settings,
   LogOut,
   PanelLeftClose,
   PanelLeftOpen,
@@ -16,22 +12,18 @@ import {
 import { cn } from "@/lib/utils";
 import { signOutAction } from "@/lib/actions/auth";
 import { ThemeToggle } from "@/components/layout/theme-toggle";
-
-const navItems = [
-  { href: "/dashboard", label: "Dashboard", icon: LayoutDashboard },
-  { href: "/opportunities", label: "Opportunities", icon: Briefcase },
-  { href: "/insights", label: "Insights", icon: BarChart3 },
-  { href: "/opportunities?archived=true", label: "Archive", icon: Archive },
-];
-
-const bottomItems = [
-  { href: "/settings", label: "Settings", icon: Settings },
-];
+import {
+  navItems,
+  bottomItems,
+  filterNavItems,
+  type FeatureFlags,
+} from "@/components/layout/nav-items";
 
 interface SidebarProps {
   collapsed: boolean;
   onToggle: () => void;
   authEnabled: boolean;
+  flags: FeatureFlags;
   mobileOpen: boolean;
   onMobileClose: () => void;
 }
@@ -87,12 +79,16 @@ export function Sidebar({
   collapsed,
   onToggle,
   authEnabled,
+  flags,
   mobileOpen,
   onMobileClose,
 }: SidebarProps) {
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const archived = searchParams.get("archived") === "true";
+
+  const mainNav = filterNavItems(navItems, flags);
+  const bottomNav = filterNavItems(bottomItems, flags);
 
   const sidebarContent = (
     <div className="flex h-full flex-col bg-sidebar text-sidebar-foreground">
@@ -119,7 +115,7 @@ export function Sidebar({
 
       {/* Main nav */}
       <nav className="flex-1 space-y-1 px-3 py-4">
-        {navItems.map((item) => (
+        {mainNav.map((item) => (
           <NavLink
             key={item.href}
             {...item}
@@ -132,7 +128,7 @@ export function Sidebar({
 
       {/* Bottom nav */}
       <div className="space-y-1 border-t border-sidebar-border px-3 py-4">
-        {bottomItems.map((item) => (
+        {bottomNav.map((item) => (
           <NavLink
             key={item.href}
             {...item}

--- a/src/components/layout/top-bar.tsx
+++ b/src/components/layout/top-bar.tsx
@@ -7,6 +7,8 @@ import { Input } from "@/components/ui/input";
 
 interface TopBarProps {
   user: { name?: string | null; email?: string | null; image?: string | null } | null;
+  /** Show the notifications bell — gated by the Alerts feature flag. */
+  showAlerts: boolean;
   onMobileMenuClick: () => void;
 }
 
@@ -39,7 +41,7 @@ function UserAvatar({
   );
 }
 
-export function TopBar({ user, onMobileMenuClick }: TopBarProps) {
+export function TopBar({ user, showAlerts, onMobileMenuClick }: TopBarProps) {
   const router = useRouter();
   const searchParams = useSearchParams();
   const currentSearch = searchParams.get("search") ?? "";
@@ -113,9 +115,14 @@ export function TopBar({ user, onMobileMenuClick }: TopBarProps) {
 
       {/* Right side */}
       <div className="ml-auto flex items-center gap-3">
-        <button className="relative p-2 rounded-md hover:bg-accent text-muted-foreground">
-          <Bell className="size-5" />
-        </button>
+        {showAlerts && (
+          <button
+            aria-label="Notifications"
+            className="relative p-2 rounded-md hover:bg-accent text-muted-foreground"
+          >
+            <Bell className="size-5" />
+          </button>
+        )}
 
         {user && (
           <div className="flex items-center gap-2">

--- a/src/lib/flags.ts
+++ b/src/lib/flags.ts
@@ -12,26 +12,36 @@ import { flag } from "flags/next";
  * guard in the page, and its `flag:` key in nav-items.ts.
  */
 
+/**
+ * True only when the env var holds "true". Tolerant of surrounding
+ * whitespace and casing so a hand-typed `.env.local` value (or Vercel's
+ * Boolean-typed variable, which serialises to the string "true") can't
+ * silently misfire. Anything else — including unset — is off.
+ */
+function isEnabled(value: string | undefined): boolean {
+  return value?.trim().toLowerCase() === "true";
+}
+
 export const dashboardFlag = flag<boolean>({
   key: "dashboard",
   defaultValue: false,
-  decide: () => process.env.FLAG_DASHBOARD === "true",
+  decide: () => isEnabled(process.env.FLAG_DASHBOARD),
 });
 
 export const insightsFlag = flag<boolean>({
   key: "insights",
   defaultValue: false,
-  decide: () => process.env.FLAG_INSIGHTS === "true",
+  decide: () => isEnabled(process.env.FLAG_INSIGHTS),
 });
 
 export const settingsFlag = flag<boolean>({
   key: "settings",
   defaultValue: false,
-  decide: () => process.env.FLAG_SETTINGS === "true",
+  decide: () => isEnabled(process.env.FLAG_SETTINGS),
 });
 
 export const alertsFlag = flag<boolean>({
   key: "alerts",
   defaultValue: false,
-  decide: () => process.env.FLAG_ALERTS === "true",
+  decide: () => isEnabled(process.env.FLAG_ALERTS),
 });

--- a/src/lib/flags.ts
+++ b/src/lib/flags.ts
@@ -1,0 +1,37 @@
+import { flag } from "flags/next";
+
+/**
+ * Feature flags for unbuilt pages — see issue #61 and
+ * docs/adr/0001-vercel-flags-sdk-over-env-checks.md.
+ *
+ * Each flag defaults to `false` and is enabled per-environment by setting
+ * the matching `FLAG_*` env var to "true" (`.env.local` for local dev,
+ * the Vercel Preview/Production env scopes for deployments).
+ *
+ * When a feature actually ships, delete its flag here, its `notFound()`
+ * guard in the page, and its `flag:` key in nav-items.ts.
+ */
+
+export const dashboardFlag = flag<boolean>({
+  key: "dashboard",
+  defaultValue: false,
+  decide: () => process.env.FLAG_DASHBOARD === "true",
+});
+
+export const insightsFlag = flag<boolean>({
+  key: "insights",
+  defaultValue: false,
+  decide: () => process.env.FLAG_INSIGHTS === "true",
+});
+
+export const settingsFlag = flag<boolean>({
+  key: "settings",
+  defaultValue: false,
+  decide: () => process.env.FLAG_SETTINGS === "true",
+});
+
+export const alertsFlag = flag<boolean>({
+  key: "alerts",
+  defaultValue: false,
+  decide: () => process.env.FLAG_ALERTS === "true",
+});


### PR DESCRIPTION
Closes #61.

## Summary

Puts the unbuilt **Dashboard**, **Insights**, **Settings**, and **Alerts** pages behind env-var-backed feature flags built on the [Vercel Flags SDK](https://flags-sdk.dev/). When a flag is **off** the sidebar link is hidden and the route returns 404; when **on**, the link appears and the page renders. Flags default off in every environment.

Rationale for using the Flags SDK over raw `process.env` checks is recorded in [ADR-0001](docs/adr/0001-vercel-flags-sdk-over-env-checks.md).

## What changed

- **`src/lib/flags.ts`** — four flags (`dashboardFlag`, `insightsFlag`, `settingsFlag`, `alertsFlag`) via `flag()` from `flags/next`, each reading a `FLAG_*` env var.
- **`src/components/layout/nav-items.ts`** — nav config + `FeatureFlag` types + the pure `filterNavItems()` helper.
- **`src/components/layout/nav-items.test.ts`** — Vitest coverage for `filterNavItems()`.
- The `(app)` layout evaluates all four flags and passes them through `AppShell` to the `Sidebar` and `TopBar`.
- `dashboard` / `insights` / `settings` pages gated with `notFound()`; new `alerts` stub page added.
- The `TopBar` notification bell is gated on the alerts flag, so the whole Alerts surface (route + sidebar link + bell) toggles as one unit.

## Enabling a flag in Vercel

Flags are read from `FLAG_*` environment variables, so turning a feature on in a deployed environment is just an env-var change — no code change, no adapter.

> ⚠️ **Use Settings → Environment Variables, _not_ the Vercel Flags dashboard.** Vercel's "Flags" dashboard (with per-environment "Rules") stores values in Edge Config and never populates `process.env` — the code here can't read it. These flags are plain environment variables.

1. In the Vercel dashboard, open the project → **Settings** → **Environment Variables**.
2. Add a variable:
   - **Key** — one of `FLAG_DASHBOARD`, `FLAG_INSIGHTS`, `FLAG_SETTINGS`, `FLAG_ALERTS`
   - **Type** — **Boolean** is recommended (a toggle that can't be fat-fingered). `String` also works — the flag reads the value as text either way — but Boolean avoids typos like `True`/trailing-space silently leaving the feature off.
   - **Value** — toggle on / `true` to enable; off or unset keeps the feature off.
3. Choose the **Environment** scope — these are independent:
   - **Preview** — enable a flag here to dogfood an in-progress feature via preview links while it stays hidden in Production.
   - **Production** — enable a flag here when the feature is ready to ship.
4. **Redeploy** the affected environment for the change to take effect (env-var changes don't apply to existing deployments).

To turn a feature back off, toggle the variable off (or delete it) and redeploy.

The flag's `decide` normalises the value (`trim().toLowerCase()`), so both Vercel's Boolean value and a hand-typed `.env.local` string resolve correctly. Locally, set the same `FLAG_*=true` vars in `.env.local` — see the new "Feature flags" section in the README and `.env.example`.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm run test` — 28 passed (5 new for `filterNavItems`)
- [x] `npm run build` — succeeds; gated routes render dynamically as expected
- [x] All flags unset → sidebar shows only Opportunities + Archive; `/dashboard`, `/insights`, `/settings`, `/alerts` all 404; no TopBar bell
- [x] `FLAG_DASHBOARD` + `FLAG_ALERTS` set → those links appear, pages render 200, bell shows; `/insights` + `/settings` stay 404 (flags are independent)

> Note: `npm run lint` reports 2 pre-existing errors in `opportunity-table.tsx` / `opportunity-form.tsx` (`setState` in effect) unrelated to this change — no files touched here introduce lint issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
