### PR TITLE
Add Capture/Import glossary terms + ADR-0002 landing-page honesty rule

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -8,6 +8,14 @@ A job-opportunity tracker. The domain models a single user's progression of job 
 A single job posting the user is tracking — company + role + a few attributes. The central entity; every other concept hangs off it.
 _Avoid_: Application, lead, job (ambiguous), posting
 
+**Capture**:
+Creating a single **Opportunity** from a pasted job URL or job-description text via an LLM, instead of manual field entry.
+_Avoid_: Import (reserved for the CSV path), parse, scrape, AI add
+
+**Import**:
+Bulk creation of many **Opportunities** from a CSV file — an administrative operation, not part of the in-app flow.
+_Avoid_: Capture, upload, sync
+
 **Status**:
 Where the **Opportunity** sits in the application pipeline. One of a fixed set of seven values: `saved`, `applied`, `interviewing`, `offered`, `rejected`, `withdrawn`, `accepted`. Lives as a text column, not a separate table.
 _Avoid_: State, stage, phase
@@ -30,6 +38,7 @@ _Avoid_: Audit log, timeline (the UI uses "timeline" for the combined history + 
 
 ## Relationships
 
+- An **Opportunity** enters the system one of three ways: manual field entry, **Capture**, or **Import**.
 - An **Opportunity** has exactly one current **Status** and one **Archived** state.
 - An **Opportunity** has zero or more **Status History** entries, one per real **Status** transition.
 - **Status** and **Archived** are independent: any combination is valid.
@@ -47,3 +56,4 @@ _Avoid_: Audit log, timeline (the UI uses "timeline" for the combined history + 
 
 - **"Status" vs "Archived"** are sometimes spoken about as if interchangeable ("change its status to archived"), but in the schema they are independent columns. **Archived** is not a **Status** value. When a user says "mark as archived," they mean toggling the boolean, not changing the seven-value **Status** enum.
 - **"Timeline"** is used by the UI to mean the combined view of **Status History** + comments on an **Opportunity** detail page. When referring strictly to status transitions, use **Status History**.
+- **"Import"** was used informally for both the CSV bulk path and the AI single-opportunity feature — resolved: **Import** is CSV-only; the AI feature is **Capture**.

--- a/docs/adr/0002-landing-page-only-advertises-shipped-features.md
+++ b/docs/adr/0002-landing-page-only-advertises-shipped-features.md
@@ -1,0 +1,5 @@
+# The landing page only advertises shipped features
+
+The marketing page at `/` describes the product to anonymous visitors of the hosted `nextopp.app` deployment, and is a real conversion surface — so every claim on it must be true the moment a visitor signs up. Today the page advertises features that don't exist (e.g. Dashboard and Insights, which are gated as unbuilt stubs behind [`flags.ts`](../../src/lib/flags.ts) per [ADR-0001](./0001-vercel-flags-sdk-over-env-checks.md)); we are removing that vaporware as part of the redesign.
+
+We decided the page advertises **only features that are actually shipped** — no roadmap teasers, no "coming soon" sections, even for differentiated future work like AI matching. When a gated feature ships, **updating the landing copy and screenshots is part of that feature's PR**, alongside the flag removal and the sidebar gate removal already mandated by ADR-0001. The trade-off rejected here is the standard SaaS "tease the roadmap" move, which trades short-term marketing lift for credibility every time a visitor signs up and finds the teased feature missing — a leak we'd then have to fix anyway.


### PR DESCRIPTION
## Summary

- Resolves the **"import" overload** in [CONTEXT.md](CONTEXT.md): defines **Capture** as the AI single-opportunity creation feature, and reserves **Import** for the CSV bulk path. Adds a flagged-ambiguity note recording the resolution.
- Adds [**ADR-0002**](docs/adr/0002-landing-page-only-advertises-shipped-features.md): the landing page at `/` advertises only shipped features (no roadmap teasers, no "coming soon"), and refreshing landing copy/screenshots is part of the shipping PR for any previously-gated feature — the mechanical complement to [ADR-0001](docs/adr/0001-vercel-flags-sdk-over-env-checks.md).

## Why now

Both docs came out of the design session for the pre-login landing page redesign ([#85](https://github.com/zachradtka/opportunity-tracker/issues/85)). They're prerequisites for that implementation, but they also stand on their own as glossary + process artifacts — so they ship as a small docs-only PR ahead of the redesign code.

## Test plan

- [ ] CONTEXT.md renders correctly on the GitHub web view
- [ ] ADR-0002 renders correctly and the cross-link to ADR-0001 resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)