### PR TITLE
Landing redesign · Slice 1: Foundation (#87)

### DIFF
--- a/src/app/(marketing)/_components/CtaBand.tsx
+++ b/src/app/(marketing)/_components/CtaBand.tsx
@@ -1,0 +1,14 @@
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+
+export function CtaBand() {
+  return (
+    <section className="flex flex-col items-center py-12 text-center sm:py-16">
+      <Link href="/login">
+        <Button size="lg" className="h-11 px-6 text-base">
+          Get started
+        </Button>
+      </Link>
+    </section>
+  );
+}

--- a/src/app/(marketing)/_components/FeatureSection.tsx
+++ b/src/app/(marketing)/_components/FeatureSection.tsx
@@ -1,0 +1,22 @@
+import type { LandingFeature } from "../_lib/landing-features";
+
+export function FeatureSection({ features }: { features: LandingFeature[] }) {
+  if (features.length === 0) return null;
+
+  return (
+    <section className="grid gap-6 pb-16 sm:gap-8 sm:pb-24 md:grid-cols-3 lg:pb-32">
+      {features.map(({ icon: Icon, title, body }) => (
+        <div
+          key={title}
+          className="flex flex-col rounded-xl border border-border bg-card p-6 text-card-foreground"
+        >
+          <div className="mb-4 flex size-10 items-center justify-center rounded-lg bg-primary/10 text-primary">
+            <Icon className="size-5" />
+          </div>
+          <h2 className="text-lg font-semibold">{title}</h2>
+          <p className="mt-2 text-sm text-muted-foreground">{body}</p>
+        </div>
+      ))}
+    </section>
+  );
+}

--- a/src/app/(marketing)/_components/Hero.tsx
+++ b/src/app/(marketing)/_components/Hero.tsx
@@ -1,0 +1,23 @@
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+
+export function Hero() {
+  return (
+    <section className="flex flex-col items-center py-16 text-center sm:py-24 lg:py-32">
+      <h1 className="text-balance text-4xl font-bold tracking-tight sm:text-5xl lg:text-6xl">
+        A central place for your entire interviewing journey
+      </h1>
+      <p className="mt-6 max-w-2xl text-balance text-base text-muted-foreground sm:text-lg">
+        Track applications, manage your interview pipeline, and capture every
+        conversation along the way — all in one place.
+      </p>
+      <div className="mt-8">
+        <Link href="/login">
+          <Button size="lg" className="h-11 px-6 text-base">
+            Get started
+          </Button>
+        </Link>
+      </div>
+    </section>
+  );
+}

--- a/src/app/(marketing)/_components/ScreenshotFrame.tsx
+++ b/src/app/(marketing)/_components/ScreenshotFrame.tsx
@@ -1,0 +1,9 @@
+import type { ReactNode } from "react";
+
+export function ScreenshotFrame({ children }: { children?: ReactNode }) {
+  return (
+    <div className="overflow-hidden rounded-xl border border-border bg-card">
+      {children}
+    </div>
+  );
+}

--- a/src/app/(marketing)/_lib/landing-features.test.ts
+++ b/src/app/(marketing)/_lib/landing-features.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from "vitest";
+import { landingFeatures } from "./landing-features";
+import * as flagsModule from "@/lib/flags";
+
+describe("landing-features", () => {
+  it("never advertises a flag-gated feature (ADR-0002)", () => {
+    const flagKeys = new Set(
+      Object.values(flagsModule)
+        .filter(
+          (value): value is { key: string } =>
+            typeof value === "function" &&
+            typeof (value as { key?: unknown }).key === "string",
+        )
+        .map((flag) => flag.key),
+    );
+
+    for (const feature of landingFeatures) {
+      if (feature.flagKey === null) continue;
+      expect(
+        flagKeys.has(feature.flagKey),
+        `landingFeatures advertises "${feature.title}" with flagKey "${feature.flagKey}", which matches a gated flag in src/lib/flags.ts — per ADR-0002 only shipped features may appear on the landing page`,
+      ).toBe(false);
+    }
+  });
+});

--- a/src/app/(marketing)/_lib/landing-features.ts
+++ b/src/app/(marketing)/_lib/landing-features.ts
@@ -1,0 +1,10 @@
+import type { LucideIcon } from "lucide-react";
+
+export type LandingFeature = {
+  icon: LucideIcon;
+  title: string;
+  body: string;
+  flagKey: string | null;
+};
+
+export const landingFeatures: LandingFeature[] = [];

--- a/src/app/(marketing)/layout.tsx
+++ b/src/app/(marketing)/layout.tsx
@@ -8,7 +8,7 @@ export default function MarketingLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <div className="flex h-full flex-col overflow-y-auto bg-background">
+    <div className="dark flex h-full flex-col overflow-y-auto bg-background">
       <header className="sticky top-0 z-10 border-b border-border bg-background/80 backdrop-blur">
         <div className="mx-auto flex h-14 w-full max-w-6xl items-center justify-between px-4 sm:px-6 lg:px-8">
           <Link

--- a/src/app/(marketing)/page.tsx
+++ b/src/app/(marketing)/page.tsx
@@ -1,33 +1,16 @@
-import Link from "next/link";
 import type { Metadata } from "next";
 import { redirect } from "next/navigation";
-import { ListChecks, GitBranch, MessageSquareText } from "lucide-react";
 import { getOptionalSession, isAuthEnabled } from "@/lib/auth-optional";
-import { Button } from "@/components/ui/button";
+import { Hero } from "./_components/Hero";
+import { FeatureSection } from "./_components/FeatureSection";
+import { CtaBand } from "./_components/CtaBand";
+import { landingFeatures } from "./_lib/landing-features";
 
 export const metadata: Metadata = {
   title: "NextOpp — track your interviewing journey",
   description:
     "A central place to track job applications, manage your interview pipeline, and log every update along the way.",
 };
-
-const features = [
-  {
-    icon: ListChecks,
-    title: "Track applications",
-    body: "Capture every opportunity and watch it move from Saved to Applied to Interviewing — without losing track of where each role stands.",
-  },
-  {
-    icon: GitBranch,
-    title: "Pipeline at a glance",
-    body: "Status counts, dashboards, and insights show your whole search at once so you know where to focus next.",
-  },
-  {
-    icon: MessageSquareText,
-    title: "Comments and timeline",
-    body: "Log calls, interviews, and follow-ups as rich-text comments. Every opportunity has a full timeline of your conversation history.",
-  },
-];
 
 export default async function LandingPage() {
   if (!isAuthEnabled()) {
@@ -40,37 +23,9 @@ export default async function LandingPage() {
 
   return (
     <div className="mx-auto w-full max-w-6xl px-4 sm:px-6 lg:px-8">
-      <section className="flex flex-col items-center py-16 text-center sm:py-24 lg:py-32">
-        <h1 className="text-balance text-4xl font-bold tracking-tight sm:text-5xl lg:text-6xl">
-          A central place for your entire interviewing journey
-        </h1>
-        <p className="mt-6 max-w-2xl text-balance text-base text-muted-foreground sm:text-lg">
-          Track applications, manage your interview pipeline, and capture every
-          conversation along the way — all in one place.
-        </p>
-        <div className="mt-8">
-          <Link href="/login">
-            <Button size="lg" className="h-11 px-6 text-base">
-              Sign in to get started
-            </Button>
-          </Link>
-        </div>
-      </section>
-
-      <section className="grid gap-6 pb-16 sm:gap-8 sm:pb-24 md:grid-cols-3 lg:pb-32">
-        {features.map(({ icon: Icon, title, body }) => (
-          <div
-            key={title}
-            className="flex flex-col rounded-xl border border-border bg-card p-6 text-card-foreground"
-          >
-            <div className="mb-4 flex size-10 items-center justify-center rounded-lg bg-primary/10 text-primary">
-              <Icon className="size-5" />
-            </div>
-            <h2 className="text-lg font-semibold">{title}</h2>
-            <p className="mt-2 text-sm text-muted-foreground">{body}</p>
-          </div>
-        ))}
-      </section>
+      <Hero />
+      <FeatureSection features={landingFeatures} />
+      <CtaBand />
     </div>
   );
 }

--- a/src/app/(marketing)/sign-in-button.tsx
+++ b/src/app/(marketing)/sign-in-button.tsx
@@ -11,7 +11,7 @@ export function SignInButton() {
   return (
     <Link href="/login">
       <Button size="sm" className="sm:h-8 sm:px-3">
-        Sign in
+        Get started
       </Button>
     </Link>
   );


### PR DESCRIPTION
Closes #87. First of three slices for #85.

## Summary
- Pin the `(marketing)` route group to dark mode via `.dark` on the layout root (rest of the app stays on `defaultTheme="system"`).
- Rename the marketing header CTA "Sign in" → "Get started" (same `/login` link, same auth-state behavior).
- Replace the landing body — which advertised the gated Dashboard/Insights features — with empty stubs of `Hero`, `FeatureSection`, and `CtaBand` under `src/app/(marketing)/_components/`. Slices 2 and 3 fill in the real content.
- Add the `_lib/landing-features.ts` data module (typed `LandingFeature[]`, initially `[]`, every entry must carry `flagKey: string | null`) and the matching vitest guard that enforces ADR-0002 mechanically: a feature whose `flagKey` collides with any exported `key` in `src/lib/flags.ts` fails the test.

Redirect behavior is unchanged: `AUTH_DISABLED=true` and authenticated visitors continue to be redirected from `/` to `/opportunities`.

## Test plan
- [ ] `npm test` passes (29/29, including the new ADR-0002 guard)
- [ ] `npm run build` succeeds
- [ ] `npm run lint` introduces no new findings (6 pre-existing problems remain on `main`)
- [ ] Visit `/` while signed out → page renders in dark mode regardless of system theme
- [ ] Visit `/login` → also dark mode (same route group)
- [ ] Visit any non-marketing route → still follows the user's system theme
- [ ] With `AUTH_DISABLED=true`, `/` redirects to `/opportunities`
- [ ] Header CTA reads "Get started" and routes to `/login`
- [ ] No occurrence of the word **Import** anywhere on the page

🤖 Generated with [Claude Code](https://claude.com/claude-code)