### PR TITLE
Rename package + repo references to nextopp (#60)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,7 +63,7 @@ TURSO_DATABASE_URL=<preview-url> TURSO_AUTH_TOKEN=<preview-token> \
 
 ## GitHub Issues
 
-Feature backlog is tracked in GitHub Issues: https://github.com/zachradtka/opportunity-tracker/issues
+Feature backlog is tracked in GitHub Issues: https://github.com/zachradtka/nextopp/issues
 
 ## AI Parsing
 
@@ -84,7 +84,7 @@ Feature backlog is tracked in GitHub Issues: https://github.com/zachradtka/oppor
 
 ### Issue tracker
 
-Issues are tracked in GitHub Issues (`zachradtka/opportunity-tracker`) via the `gh` CLI. See `docs/agents/issue-tracker.md`.
+Issues are tracked in GitHub Issues (`zachradtka/nextopp`) via the `gh` CLI. See `docs/agents/issue-tracker.md`.
 
 ### Triage labels
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Built with Next.js, SQLite, and Tailwind CSS.
 
 ```bash
 git clone <your-repo-url>
-cd opportunity-tracker
+cd nextopp
 npm install
 ```
 
@@ -135,11 +135,11 @@ curl -sSfL https://get.tur.so/install.sh | bash
 turso auth login
 
 # Create a database
-turso db create opportunity-tracker
+turso db create nextopp
 
 # Get your credentials
-turso db show opportunity-tracker --url
-turso db tokens create opportunity-tracker
+turso db show nextopp --url
+turso db tokens create nextopp
 ```
 
 ### 2. Push the schema to Turso
@@ -166,7 +166,7 @@ TURSO_DATABASE_URL=<your-url> TURSO_AUTH_TOKEN=<your-token> npm run db:push
 
 Once your app is deployed and you have your production URL:
 
-1. Set up one or more auth providers (see [Authentication](#authentication-optional) above), using your production URL for callback URLs (e.g. `https://your-app.vercel.app/api/auth/callback/github`)
+1. Set up one or more auth providers (see [Authentication](#authentication-optional) above), using your production URL for callback URLs (e.g. `https://nextopp.app/api/auth/callback/github`)
 2. Add these environment variables in Vercel:
 
 | Variable | Value |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "opportunity-tracker",
+  "name": "nextopp",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "opportunity-tracker",
+      "name": "nextopp",
       "version": "0.1.0",
       "dependencies": {
         "@auth/drizzle-adapter": "^1.11.2",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "opportunity-tracker",
+  "name": "nextopp",
   "version": "0.1.0",
   "private": true,
   "scripts": {

--- a/src/app/(marketing)/layout.tsx
+++ b/src/app/(marketing)/layout.tsx
@@ -34,7 +34,7 @@ export default function MarketingLayout({
           </nav>
           <div className="flex items-start sm:justify-end">
             <a
-              href="https://github.com/zachradtka/opportunity-tracker"
+              href="https://github.com/zachradtka/nextopp"
               target="_blank"
               rel="noopener noreferrer"
               className="hover:text-foreground"


### PR DESCRIPTION
## Summary

Code/docs portion of the [domain migration to nextopp.app](https://github.com/zachradtka/opportunity-tracker/issues/60). The rest of the work (Vercel custom domain, Cloudflare DNS, OAuth callback URLs, Resend `mail.nextopp.app` verification, GitHub repo rename) is operational and happens outside this PR — see the issue for the full cutover order.

- [package.json](package.json) → `"name": "nextopp"` + lockfile regen
- [src/app/(marketing)/layout.tsx:37](src/app/(marketing)/layout.tsx#L37) — footer "View on GitHub" link → `zachradtka/nextopp`
- [README.md](README.md) — `cd nextopp`, Turso `nextopp` example, callback URL example uses `nextopp.app`
- [CLAUDE.md](CLAUDE.md) — issues URL + repo slug

Per the issue's resolved decisions:
- Existing prod/preview Turso DBs are NOT renamed — README example only.
- Hardcoded Resend fallback in `src/lib/auth.ts:40` stays `noreply@resend.dev` for OSS-friendly fresh clones.

## Test plan

- [x] `npm run build` passes
- [ ] After merge: Vercel deploy succeeds against the renamed repo
- [ ] Footer "View on GitHub" link resolves to `github.com/zachradtka/nextopp`

🤖 Generated with [Claude Code](https://claude.com/claude-code)