### PR TITLE
Fix dropped characters in the search input

### DIFF
--- a/src/components/layout/top-bar.tsx
+++ b/src/components/layout/top-bar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { Menu, Search, Bell, X } from "lucide-react";
 import { Input } from "@/components/ui/input";
@@ -46,9 +46,14 @@ export function TopBar({ user, showAlerts, onMobileMenuClick }: TopBarProps) {
   const searchParams = useSearchParams();
   const currentSearch = searchParams.get("search") ?? "";
   const [value, setValue] = useState(currentSearch);
+  // Tracks the last search value we wrote to the URL ourselves, so the sync
+  // effect below can ignore our own round-trips and only react to external
+  // URL changes (back/forward navigation, link clicks).
+  const lastPushedRef = useRef(currentSearch);
 
-  // Sync local state when URL param changes externally
   useEffect(() => {
+    if (currentSearch === lastPushedRef.current) return;
+    lastPushedRef.current = currentSearch;
     setValue(currentSearch);
   }, [currentSearch]);
 
@@ -66,6 +71,7 @@ export function TopBar({ user, showAlerts, onMobileMenuClick }: TopBarProps) {
       } else {
         params.delete("search");
       }
+      lastPushedRef.current = trimmed;
       router.push(`/opportunities?${params.toString()}`);
     }, 300);
 
@@ -78,6 +84,7 @@ export function TopBar({ user, showAlerts, onMobileMenuClick }: TopBarProps) {
     params.delete("archived");
     params.delete("status");
     params.delete("search");
+    lastPushedRef.current = "";
     router.push(`/opportunities?${params.toString()}`);
   }, [searchParams, router]);
 


### PR DESCRIPTION
## Summary
- The top-bar search input was dropping a character every time the URL updated mid-type, because the URL → state sync effect fired on every `searchParams` change — including our own `router.push` round-trips — and overwrote the local input value in the render window between push and re-sync.
- Now we track the last value we pushed ourselves and skip the sync when the URL change matches it, so the effect only reacts to external navigation (back/forward, link clicks).

## Repro / verification
Deterministic Playwright loop: type a known string with ~310ms gaps (just over the 300ms debounce) and read the final input value.

| Typed | Before | After |
|---|---|---|
| `opportunity` (11 chars) | `opruiy` (6) | `opportunity` (11) ✓ |

Also verified that external URL changes (back button, link clicks) still sync the input correctly after the fix.

## Test plan
- [ ] Type a long-ish query (e.g. "opportunity", "senior engineer", a company name) in the top-bar search and confirm no characters are dropped at any typing speed
- [ ] Submit a search, hit the back button, confirm the input value reverts to match the URL
- [ ] Click the X to clear search, confirm input clears and URL updates
- [ ] Click a sidebar link with a different `?search=` param (or paste a URL with one) and confirm the input picks it up

🤖 Generated with [Claude Code](https://claude.com/claude-code)